### PR TITLE
Ignore annotations when mocking

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,75 @@
+name: Test downstream projects
+
+on:
+  push:
+    branches:
+      - "master"
+    paths-ignore:
+      - '.gitignore'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+      - '.all-contributorsrc'
+  pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - 'CODEOWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+      - '.all-contributorsrc'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+      shell: bash
+    - name: Cache Maven Repository
+      id: cache-maven
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        # refresh cache every month to avoid unlimited growth
+        key: maven-repo-pr-downstream-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Build with Maven
+      run: mvn -B install --file pom.xml
+
+    - name: Install xmlstarlet
+      run: sudo apt-get install xmlstarlet
+
+    - name: Get project version
+      id: get-version
+      run: |
+        echo "::set-output name=version::$(xmlstarlet sel -N maven='http://maven.apache.org/POM/4.0.0' -t -v '/maven:project/maven:version' pom.xml)"
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+        repository: quarkusio/quarkus-bot-java
+        path: quarkus-bot-java
+
+    - name: Update quarkus-github-app version
+      run: mvn -B versions:set-property -Dproperty=quarkus-github-app.version -DnewVersion=${{ steps.get-version.outputs.version }}
+      working-directory: quarkus-bot-java
+
+    - name: Run quarkus-bot-java tests
+      run: mvn -B install
+      working-directory: quarkus-bot-java
+

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/CallRealMethodAndSpyGHObjectResults.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/CallRealMethodAndSpyGHObjectResults.java
@@ -27,6 +27,7 @@ final class CallRealMethodAndSpyGHObjectResults implements Answer<Object>, Seria
         Class<? extends GHObject> type = castOriginal.getClass();
         DefaultableMocking<? extends GHObject> mocking = mocks.ghObjectMocking(castOriginal);
         return Mockito.mock(type, withSettings().stubOnly()
+                .withoutAnnotations()
                 .spiedInstance(original)
                 .defaultAnswer(new CallMockedMethodOrCallRealMethodAndSpyGHObjectResults(this, mocking)));
     }

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/DefaultableMocking.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/DefaultableMocking.java
@@ -15,7 +15,10 @@ final class DefaultableMocking<M> {
     static <M> DefaultableMocking<M> create(Class<M> clazz, Object id) {
         StubDetectingInvocationListener listener = new StubDetectingInvocationListener();
         M mock = Mockito.mock(clazz,
-                Mockito.withSettings().name(clazz.getSimpleName() + "#" + id).invocationListeners(listener));
+                Mockito.withSettings()
+                        .name(clazz.getSimpleName() + "#" + id)
+                        .withoutAnnotations()
+                        .invocationListeners(listener));
         return new DefaultableMocking<>(mock, listener);
     }
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -51,6 +51,7 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
                 when(newClient.parseEventPayload(any(), any())).thenAnswer(invocation -> {
                     Object original = invocation.callRealMethod();
                     return Mockito.mock(original.getClass(), withSettings().spiedInstance(original)
+                            .withoutAnnotations()
                             .defaultAnswer(new CallRealMethodAndSpyGHObjectResults(this)));
                 });
             } catch (IOException e) {


### PR DESCRIPTION
Some annotations (@Preview) reference protected classes which doesn't
work well with mocking.