### PR TITLE
Allow more GHObject mock types 

### DIFF
--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.githubapp.testing.dsl;
 
 import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHObject;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
@@ -14,6 +15,8 @@ public interface GitHubMockContext {
     GHIssue issue(long id);
 
     GHPullRequest pullRequest(long id);
+
+    <T extends GHObject> T ghObject(Class<T> type, long id);
 
     Object[] ghObjects();
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockSetupContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockSetupContext.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 
 public interface GitHubMockSetupContext extends GitHubMockContext {
 
-    <T> void configFileFromClasspath(String pathInRepository, String pathInClassPath) throws IOException;
+    void configFileFromClasspath(String pathInRepository, String pathInClassPath) throws IOException;
 
-    <T> void configFileFromString(String pathInRepository, String configFile);
+    void configFileFromString(String pathInRepository, String configFile);
 
 }

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -79,12 +79,17 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
 
     @Override
     public GHIssue issue(long id) {
-        return nonRepositoryMockMap(GHIssue.class).getOrCreate(id).mock();
+        return ghObject(GHIssue.class, id);
     }
 
     @Override
     public GHPullRequest pullRequest(long id) {
-        return nonRepositoryMockMap(GHPullRequest.class).getOrCreate(id).mock();
+        return ghObject(GHPullRequest.class, id);
+    }
+
+    @Override
+    public <T extends GHObject> T ghObject(Class<T> type, long id) {
+        return nonRepositoryMockMap(type).getOrCreate(id).mock();
     }
 
     @Override

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -62,12 +62,12 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     }
 
     @Override
-    public <T> void configFileFromClasspath(String pathInRepository, String pathInClassPath) throws IOException {
+    public void configFileFromClasspath(String pathInRepository, String pathInClassPath) throws IOException {
         configFileFromString(pathInRepository, GitHubAppTestingContext.get().getFromClasspath(pathInClassPath));
     }
 
     @Override
-    public <T> void configFileFromString(String pathInRepository, String configFile) {
+    public void configFileFromString(String pathInRepository, String configFile) {
         when(fileDownloader.getFileContent(any(), eq(getGitHubFilePath(pathInRepository))))
                 .thenReturn(Optional.of(configFile));
     }


### PR DESCRIPTION
There's no reason not to, and there's a gazillion subtypes of GHObject,
so we cannot support them all explicitly.