### PR TITLE
 Avoid errors when using @githubapptest in some tests, but not all of them

### DIFF
--- a/integration-tests/testing-framework/src/test/java/io/quarkiverse/githubapp/it/testingframework/NoTestingFrameworkTest.java
+++ b/integration-tests/testing-framework/src/test/java/io/quarkiverse/githubapp/it/testingframework/NoTestingFrameworkTest.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.githubapp.it.testingframework;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+//@GithubAppTest // NOT using the testing framework on purpose
+public class NoTestingFrameworkTest {
+
+    @Test
+    void checkApplicationIncludesListeners() {
+        // We just want to check that:
+        // 1. The application started and includes our listeners
+        // 2. This test works even though we are not using @GithubAppTest (because we're not using the testing framework)
+        assertThat(Arc.container().instance(IssueEventListener.class))
+                .isNotNull();
+        assertThat(Arc.container().instance(PullRequestEventListener.class))
+                .isNotNull();
+    }
+
+}

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubAppTestingCallback.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubAppTestingCallback.java
@@ -20,7 +20,8 @@ public final class GitHubAppTestingCallback
     }
 
     static boolean isEnabled() {
-        return ConfigProviderResolver.instance().getConfig().getValue(ENABLED_KEY, Boolean.class);
+        return ConfigProviderResolver.instance().getConfig().getOptionalValue(ENABLED_KEY, Boolean.class)
+                .orElse(false);
     }
 
     @Override


### PR DESCRIPTION
This used to cause errors like this:

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 5.136 s <<< FAILURE! - in org.hibernate.infra.bot.tests.ApplicationSanityTest
[ERROR] org.hibernate.infra.bot.tests.ApplicationSanityTest.checkApplicationIncludesCheckPullRequestContributionRules  Time elapsed: 0.006 s  <<< ERROR!
org.junit.jupiter.api.extension.TestInstantiationException: Failed to create test instance
Caused by: java.lang.reflect.InvocationTargetException
Caused by: java.util.NoSuchElementException: SRCFG00014: The config property quarkiverse-github-app-testing.enabled is required but it could not be found in any config source
```