### PR TITLE
Allow configuring private instances.

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-github-app.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-github-app.adoc
@@ -55,6 +55,16 @@ The Smee.io proxy URL used when testing locally.
 |
 
 
+a| [[quarkus-github-app_quarkus.github-app.instance-endpoint]]`link:#quarkus-github-app_quarkus.github-app.instance-endpoint[quarkus.github-app.instance-endpoint]`
+
+[.description]
+--
+The GitHub instance endpoint. 
+ If not specified, defaults to the public github.com instance.
+--|string 
+|
+
+
 a| [[quarkus-github-app_quarkus.github-app.debug.payload-directory]]`link:#quarkus-github-app_quarkus.github-app.debug.payload-directory[quarkus.github-app.debug.payload-directory]`
 
 [.description]

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/GitHubAppRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/GitHubAppRuntimeConfig.java
@@ -47,7 +47,9 @@ public class GitHubAppRuntimeConfig {
     public Optional<String> webhookProxyUrl;
 
     /**
-     * The github instance endpoint.
+     * The GitHub instance endpoint.
+     * <p>
+     * If not specified, defaults to the public github.com instance.
      */
     @ConfigItem
     public Optional<String> instanceEndpoint;

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubService.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubService.java
@@ -92,7 +92,7 @@ public class GitHubService {
     private GitHub createInstallationClient(Long installationId) throws IOException {
         CachedInstallationToken installationToken = installationTokenCache.get(installationId);
 
-        final var gitHubBuilder = new GitHubBuilder().withConnector(okhttpConnector)
+        final GitHubBuilder gitHubBuilder = new GitHubBuilder().withConnector(okhttpConnector)
                 .withAppInstallationToken(installationToken.getToken());
 
         gitHubAppRuntimeConfig.instanceEndpoint.ifPresent(gitHubBuilder::withEndpoint);


### PR DESCRIPTION
Fixes #202 

* Add an `instanceEndpoint` field in `GitHubAppRuntimeConfig`.
* Use that field in `GitHubService.createInstallationClient`

