### PR TITLE
Force the use of the Java 11 HTTP client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,8 @@
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <jandex-plugin.version>1.2.1</jandex-plugin.version>
 
-        <quarkus-github-api.version>1.301.0</quarkus-github-api.version>
+        <quarkus-github-api.version>1.301.1</quarkus-github-api.version>
         <quarkus-jjwt-jackson.version>1.0.0</quarkus-jjwt-jackson.version>
-        <okhttp.version>4.9.3</okhttp.version>
         <okhttp-eventsource.version>2.3.2</okhttp-eventsource.version>
         <jjwt.version>0.11.2</jjwt.version>
 
@@ -74,11 +73,6 @@
                 <groupId>io.quarkiverse.jjwtjackson</groupId>
                 <artifactId>quarkus-jjwt-jackson-deployment</artifactId>
                 <version>${quarkus-jjwt-jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.launchdarkly</groupId>

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/graal/Delete_OkHttpGitHubConnector.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/graal/Delete_OkHttpGitHubConnector.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.githubapp.runtime.graal;
+
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * We drop this connector altogether as the OkHttp version we are using is not compatible with so we can't build the native
+ * executable with it around.
+ * <p>
+ * One option to fix it is to force using a newer version in each GitHub App project but it's not very practical, especially
+ * since we are now using OkHttp just for the event source in dev mode.
+ */
+@TargetClass(className = "org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector")
+@Delete
+public final class Delete_OkHttpGitHubConnector {
+
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/graal/Substitute_DefaultGitHubConnector.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/graal/Substitute_DefaultGitHubConnector.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.githubapp.runtime.graal;
+
+import org.kohsuke.github.connector.GitHubConnector;
+import org.kohsuke.github.extras.HttpClientGitHubConnector;
+import org.kohsuke.github.internal.DefaultGitHubConnector;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Force the Java 11 HTTP client usage.
+ */
+@TargetClass(DefaultGitHubConnector.class)
+public final class Substitute_DefaultGitHubConnector {
+
+    @Substitute
+    static GitHubConnector create(String defaultConnectorProperty) {
+        return new HttpClientGitHubConnector();
+    }
+}


### PR DESCRIPTION
The version of OkHttp used in the Quarkus BOM is very old and is not
compatible with the GitHub API anymore. Now that there is a properly
working Java 11 HTTP client implementation, we can simply drop it and
favor the Java 11 client.