### PR TITLE
Release 1.7.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus GitHub App
 release:
-  current-version: 1.6.0
-  next-version: 1.6.1-SNAPSHOT
+  current-version: 1.7.0
+  next-version: 1.7.1-SNAPSHOT
 


### PR DESCRIPTION
@jtama @gsmachado FYI, the upcoming release `1.7.0` requires an upgrade to Quarkus `2.7.0.Final`