### PR TITLE
Move error handling to the multiplexer methods

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.11.0.Final
+:quarkus-version: 2.11.1.Final
 :quarkus-github-app-version: 1.10.0
 
 :github-api-javadoc-root-url: https://github-api.kohsuke.org/apidocs/org/kohsuke/github

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/MultiplexedEvent.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/MultiplexedEvent.java
@@ -3,9 +3,12 @@ package io.quarkiverse.githubapp.runtime;
 import org.kohsuke.github.GHEventPayload;
 import org.kohsuke.github.GitHub;
 
+import io.quarkiverse.githubapp.GitHubEvent;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public class MultiplexedEvent {
+
+    private final GitHubEvent gitHubEvent;
 
     private final GHEventPayload payload;
 
@@ -13,10 +16,16 @@ public class MultiplexedEvent {
 
     private final DynamicGraphQLClient gitHubGraphQLClient;
 
-    public MultiplexedEvent(GHEventPayload payload, GitHub gitHub, DynamicGraphQLClient gitHubGraphQLClient) {
+    public MultiplexedEvent(GitHubEvent gitHubEvent, GHEventPayload payload, GitHub gitHub,
+            DynamicGraphQLClient gitHubGraphQLClient) {
+        this.gitHubEvent = gitHubEvent;
         this.payload = payload;
         this.gitHub = gitHub;
         this.gitHubGraphQLClient = gitHubGraphQLClient;
+    }
+
+    public GitHubEvent getGitHubEvent() {
+        return gitHubEvent;
     }
 
     public GHEventPayload getPayload() {


### PR DESCRIPTION
Otherwise, we now have the following errors in the log:

2022-07-29 14:52:42,378 ERROR [io.qua.arc.imp.DefaultAsyncObserverExceptionHandler] (executor-thread-0) Failure occurred while notifying an async Observer [method=io.quarkus.bot.PushToProjects_Multiplexer#issueLabeled_35c5add42697742b520a6db1fd7be53b4ad45669(io.quarkiverse.githubapp.runtime.MultiplexedEvent,io.quarkiverse.githubapp.runtime.ConfigFileReader)] for event of type io.quarkiverse.githubapp.runtime.MultiplexedEvent
- please enable debug logging to see the full stack trace