### PR TITLE
Support tests of classes which use DynamicGraphQLClient 

### DIFF
--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.githubapp.testing.dsl;
 
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHObject;
@@ -11,6 +12,8 @@ import org.kohsuke.github.GitHub;
 public interface GitHubMockContext {
 
     GitHub client(long id);
+
+    DynamicGraphQLClient graphQLClient(long id);
 
     GHRepository repository(String id);
 


### PR DESCRIPTION
As part of my (second, unpushed) fix for https://github.com/quarkusio/quarkus-github-bot/pull/257, I tried to add a test for a `PushToProjects`, a class which has the following method signature:

```
    void pullRequestLabeled(@PullRequest.Labeled GHEventPayload.PullRequest pullRequestPayload,
            @ConfigFile("quarkus-github-bot.yml") QuarkusGitHubBotConfigFile quarkusBotConfigFile,
            GitHub gitHub, DynamicGraphQLClient gitHubGraphQLClient) throws IOException {
```

That test fails with the following exception

```
[ERROR] io.quarkus.bot.it.PushToProjectsTest.triageComment  Time elapsed: 0.495 s  <<< FAILURE!
java.lang.AssertionError: The event handler threw an exception: The GraphQL client has not been initialized and should not be accessed.
        at io.quarkiverse.githubapp.testing.internal.EventSenderOptionsImpl.event(EventSenderOptionsImpl.java:111)
        at io.quarkiverse.githubapp.testing.internal.EventSenderOptionsImpl.event(EventSenderOptionsImpl.java:85)
        at io.quarkiverse.githubapp.testing.internal.EventSenderOptionsImpl.event(EventSenderOptionsImpl.java:20)
        at io.quarkus.bot.it.PushToProjectsTest.triageComment(PushToProjectsTest.java:73)
...
Caused by: java.lang.IllegalStateException: The GraphQL client has not been initialized and should not be accessed.
        at io.quarkiverse.githubapp.runtime.MultiplexedEvent.getGitHubGraphQLClient(MultiplexedEvent.java:41)
        at io.quarkus.bot.PushToProjects_Multiplexer.pullRequestLabeled_35c5add42697742b520a6db1fd7be53b4ad45669(Unknown Source)
        at io.quarkus.bot.PushToProjects_Multiplexer_Observer_pullRequestLabeled_35c5add42697742b520a6db1fd7be53b4ad45669_b65c7b03e7d0ca92e5b8d9ccb80a1a828633ab4f.notify(Unknown Source)
        at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:323)
        at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:305)
        at io.quarkus.arc.impl.EventImpl$1.get(EventImpl.java:103)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:555)
```

I couldn't figure out a good workaround at the test level, but updating the mocking support to also mock `getInstallationGraphQLClient` on `GitHubService` allows the test to proceed. 

I've done a simple mock, on the basis that once the hook is there dependencies can add behaviour if they need it. 
            