### PR TITLE
Simpler fix for #352

### DIFF
--- a/command-airline/runtime/src/main/java/io/quarkiverse/githubapp/command/airline/runtime/AbstractCommandDispatcher.java
+++ b/command-airline/runtime/src/main/java/io/quarkiverse/githubapp/command/airline/runtime/AbstractCommandDispatcher.java
@@ -28,8 +28,6 @@ import com.github.rvesse.airline.parser.errors.handlers.CollectAll;
 
 import io.quarkiverse.githubapp.command.airline.runtime.util.Commandline;
 import io.quarkiverse.githubapp.command.airline.runtime.util.Reactions;
-import io.quarkus.arc.ClientProxy;
-import io.quarkus.arc.Subclass;
 
 public abstract class AbstractCommandDispatcher<C> {
 
@@ -82,7 +80,7 @@ public abstract class AbstractCommandDispatcher<C> {
         ParseResult<C> parseResult = cli.parseWithResult(commandLine);
 
         if (parseResult.wasSuccessful()) {
-            String commandClassName = normalizeCommandClass(parseResult.getCommand().getClass()).getName();
+            String commandClassName = parseResult.getState().getCommand().getType().getName();
 
             CommandConfig commandConfig = commandConfigs.getOrDefault(commandClassName,
                     cliConfig.getDefaultCommandConfig());
@@ -111,17 +109,6 @@ public abstract class AbstractCommandDispatcher<C> {
         handleParseError(issueCommentPayload, firstLine, commandLine, parseResult);
 
         return Optional.empty();
-    }
-
-    private static Class<?> normalizeCommandClass(Class<?> commandClass) {
-        if (Subclass.class.isAssignableFrom(commandClass)) {
-            return commandClass.getSuperclass();
-        }
-        if (ClientProxy.class.isAssignableFrom(commandClass)) {
-            return commandClass.getSuperclass();
-        }
-
-        return commandClass;
     }
 
     private boolean matches(String cli) {


### PR DESCRIPTION
Rather than using the class of the command instance, we can use the
metadata directly.
Figured it out while working on the reaction strategy patch.