### PR TITLE
Always use the classloader of mocked classes when creating/configuring mocks

### DIFF
--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/MockitoUtils.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/MockitoUtils.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.githubapp.testing.internal;
+
+import java.util.function.Supplier;
+
+public class MockitoUtils {
+
+    private MockitoUtils() {
+    }
+
+    public static <T> T doWithMockedClassClassLoader(Class<?> mockedClass, Supplier<T> action) {
+        ClassLoader mockedClassClassLoader = mockedClass.getClassLoader();
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(mockedClassClassLoader);
+            return action.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
+    }
+
+}

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/mockito/internal/DefaultableMocking.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/mockito/internal/DefaultableMocking.java
@@ -23,19 +23,13 @@ public final class DefaultableMocking<M> {
     private static final MockMaker mockMaker = Plugins.getMockMaker();
 
     public static <M> DefaultableMocking<M> create(Class<M> clazz, Object id, Consumer<MockSettings> mockSettingsContributor) {
-        ClassLoader old = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(clazz.getClassLoader());
-            StubDetectingInvocationListener listener = new StubDetectingInvocationListener();
-            MockSettings mockSettings = Mockito.withSettings().name(clazz.getSimpleName() + "#" + id)
-                    .withoutAnnotations()
-                    .invocationListeners(listener);
-            mockSettingsContributor.accept(mockSettings);
-            M mock = Mockito.mock(clazz, mockSettings);
-            return new DefaultableMocking<>(mock, listener);
-        } finally {
-            Thread.currentThread().setContextClassLoader(old);
-        }
+        StubDetectingInvocationListener listener = new StubDetectingInvocationListener();
+        MockSettings mockSettings = Mockito.withSettings().name(clazz.getSimpleName() + "#" + id)
+                .withoutAnnotations()
+                .invocationListeners(listener);
+        mockSettingsContributor.accept(mockSettings);
+        M mock = Mockito.mock(clazz, mockSettings);
+        return new DefaultableMocking<>(mock, listener);
     }
 
     private final M mock;

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/mockito/internal/GHEventPayloadSpyDefaultAnswer.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/mockito/internal/GHEventPayloadSpyDefaultAnswer.java
@@ -12,6 +12,8 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import io.quarkiverse.githubapp.testing.internal.MockitoUtils;
+
 /**
  * The default answer for all {@link GHEventPayload} spies.
  * <p>
@@ -41,11 +43,13 @@ public final class GHEventPayloadSpyDefaultAnswer implements Answer<Object>, Ser
         }
         GHObject castOriginal = (GHObject) original;
         Class<? extends GHObject> type = castOriginal.getClass();
-        DefaultableMocking<? extends GHObject> mocking = defaultableMockingProvider.apply(castOriginal);
-        return Mockito.mock(type, withSettings().stubOnly()
-                .withoutAnnotations()
-                .spiedInstance(original)
-                .defaultAnswer(new GHObjectSpyDefaultAnswer(clientSpy, this, mocking)));
+        return MockitoUtils.doWithMockedClassClassLoader(type, () -> {
+            DefaultableMocking<? extends GHObject> mocking = defaultableMockingProvider.apply(castOriginal);
+            return Mockito.mock(type, withSettings().stubOnly()
+                    .withoutAnnotations()
+                    .spiedInstance(original)
+                    .defaultAnswer(new GHObjectSpyDefaultAnswer(clientSpy, this, mocking)));
+        });
     }
 
 }


### PR DESCRIPTION
This is a generalization of #172.

Initially, I started working on this in the hope of fixing https://github.com/quarkusio/quarkus-github-bot/pull/260. It turned out that was not enough, as there is a more important bug in Quarkus itself: https://github.com/quarkusio/quarkus/issues/27383.

Nevertheless, I think the change goes in the right direction, so it's worth merging.