### PR TITLE
Expose the application GitHub client so that apps can list their own installations

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/githubapp/deployment/GitHubAppProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/githubapp/deployment/GitHubAppProcessor.java
@@ -448,7 +448,7 @@ class GitHubAppProcessor {
         TryBlock tryBlock = dispatchMethodCreator.tryBlock();
 
         ResultHandle gitHubRh = tryBlock.invokeVirtualMethod(
-                MethodDescriptor.ofMethod(GitHubService.class, "getInstallationClient", GitHub.class, Long.class),
+                MethodDescriptor.ofMethod(GitHubService.class, "getInstallationClient", GitHub.class, long.class),
                 tryBlock.readInstanceField(
                         FieldDescriptor.of(dispatcherClassCreator.getClassName(), GITHUB_SERVICE_FIELD, GitHubService.class),
                         tryBlock.getThis()),
@@ -459,7 +459,7 @@ class GitHubAppProcessor {
         if (dispatchingConfiguration.requiresGraphQLClient()) {
             gitHubGraphQLClientRh = tryBlock.invokeVirtualMethod(
                     MethodDescriptor.ofMethod(GitHubService.class, "getInstallationGraphQLClient", DynamicGraphQLClient.class,
-                            Long.class),
+                            long.class),
                     tryBlock.readInstanceField(
                             FieldDescriptor.of(dispatcherClassCreator.getClassName(), GITHUB_SERVICE_FIELD,
                                     GitHubService.class),

--- a/deployment/src/test/java/io/quarkiverse/githubapp/deployment/GitHubClientProviderInjectionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/githubapp/deployment/GitHubClientProviderInjectionTest.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.githubapp.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.githubapp.GitHubClientProvider;
+import io.quarkiverse.githubapp.runtime.github.GitHubService;
+import io.quarkus.arc.Arc;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class GitHubClientProviderInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .withConfigurationResource("application.properties");
+
+    @Test
+    public void test() {
+        assertThat(Arc.container().instance(GitHubClientProvider.class).get())
+                .isInstanceOf(GitHubService.class);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/githubapp/deployment/junit/GitHubMockContextImpl.java
+++ b/deployment/src/test/java/io/quarkiverse/githubapp/deployment/junit/GitHubMockContextImpl.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.githubapp.deployment.junit;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -77,7 +78,7 @@ public final class GitHubMockContextImpl {
     void init() {
         reset();
 
-        when(service.getInstallationClient(any()))
+        when(service.getInstallationClient(anyLong()))
                 .thenAnswer(invocation -> client(invocation.getArgument(0, Long.class)));
     }
 

--- a/integration-tests/testing-framework/pom.xml
+++ b/integration-tests/testing-framework/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- For MockitoExtension; not everyone will want to use that, so the testing framework itself doesn't depend on it. -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
         <dependency>

--- a/integration-tests/testing-framework/src/main/java/io/quarkiverse/githubapp/it/testingframework/BackgroundProcessor.java
+++ b/integration-tests/testing-framework/src/main/java/io/quarkiverse/githubapp/it/testingframework/BackgroundProcessor.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.githubapp.it.testingframework;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.quarkiverse.githubapp.GitHubClientProvider;
+
+@ApplicationScoped
+public class BackgroundProcessor {
+
+    public static Behavior behavior;
+
+    @Inject
+    GitHubClientProvider clientProvider;
+
+    public void process() throws IOException {
+        behavior.execute(clientProvider);
+    }
+
+    public interface Behavior {
+        void execute(GitHubClientProvider clientProvider) throws IOException;
+    }
+}

--- a/integration-tests/testing-framework/src/test/java/io/quarkiverse/githubapp/it/testingframework/MockHelper.java
+++ b/integration-tests/testing-framework/src/test/java/io/quarkiverse/githubapp/it/testingframework/MockHelper.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.githubapp.it.testingframework;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.kohsuke.github.PagedIterator;
+import org.kohsuke.github.PagedSearchIterable;
+
+class MockHelper {
+
+    @SafeVarargs
+    @SuppressWarnings("unchecked")
+    public static <T> PagedSearchIterable<T> mockPagedIterable(T... contentMocks) {
+        PagedSearchIterable<T> iterableMock = mock(PagedSearchIterable.class);
+        when(iterableMock.iterator()).thenAnswer(ignored -> {
+            PagedIterator<T> iteratorMock = mock(PagedIterator.class);
+            Iterator<T> actualIterator = List.of(contentMocks).iterator();
+            when(iteratorMock.next()).thenAnswer(ignored2 -> actualIterator.next());
+            when(iteratorMock.hasNext()).thenAnswer(ignored2 -> actualIterator.hasNext());
+            return iteratorMock;
+        });
+        return iterableMock;
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/GitHubClientProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/GitHubClientProvider.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.githubapp;
+
+import org.kohsuke.github.GHApp;
+import org.kohsuke.github.GitHub;
+
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+
+/**
+ * A provider of {@link org.kohsuke.github.GitHub GitHub clients} for the GitHub app.
+ * <p>
+ * Inject as a CDI bean.
+ * <p>
+ * <strong>NOTE:</strong> You generally will not need this bean when processing events,
+ * as clients can be automatically injected into event listener methods,
+ * simply by adding a parameter of type {@link GitHub} or {@link DynamicGraphQLClient} to the listener method.
+ * This provider is mostly useful for non-event use cases (e.g. cron jobs).
+ */
+public interface GitHubClientProvider {
+
+    /**
+     * Gets the {@link GitHub GitHub client} for the application:
+     * it can be used without any installation, but has very little access rights (almost as little as an anonymous client).
+     * <p>
+     * The client will remain functional a few minutes at best,
+     * so you should discard it as soon as possible and retrieve another one when necessary.
+     * <p>
+     * <strong>NOTE:</strong> You generally will not need this method when processing events, as the more powerful
+     * {@link #getInstallationClient(long) installation client} gets automatically injected into event listeners.
+     * This method can still be useful for non-event use cases (e.g. cron jobs),
+     * to {@link GitHub#getApp() retrieve information about the application},
+     * in particular {@link GHApp#listInstallations() list application installations}.
+     *
+     * @return The application client.
+     */
+    GitHub getApplicationClient();
+
+    /**
+     * Gets the {@link GitHub GitHub client} for a given application installation.
+     * <p>
+     * The client will remain functional a few minutes at best,
+     * so you should discard it as soon as possible and retrieve another one when necessary.
+     * <p>
+     * <strong>NOTE:</strong> You generally will not need this method when processing events,
+     * as this client can be automatically injected into event listener listener methods,
+     * simply by adding a parameter of type {@link GitHub} to the method.
+     * This method can still be useful for non-event use cases (e.g. cron jobs),
+     * to retrieve installation clients after having {@link GHApp#listInstallations() list application installations}
+     * from the {@link #getApplicationClient() application client}.
+     *
+     * @return The client for the given installation.
+     */
+    GitHub getInstallationClient(long installationId);
+
+    /**
+     * Gets the {@link DynamicGraphQLClient GraphQL GitHub client} for a given application installation.
+     * <p>
+     * The client will remain functional a few minutes at best,
+     * so you should discard it as soon as possible and retrieve another one when necessary.
+     * <p>
+     * <strong>NOTE:</strong> You generally will not need this method when processing events,
+     * as this client can be automatically injected into event listener methods,
+     * simply by adding a parameter of type {@link DynamicGraphQLClient} to the listener method.
+     * This method can still be useful for non-event use cases (e.g. cron jobs),
+     * to retrieve installation clients after having {@link GHApp#listInstallations() list application installations}
+     * from the {@link #getApplicationClient() application client}.
+     *
+     * @return The client for the given installation.
+     */
+    DynamicGraphQLClient getInstallationGraphQLClient(long installationId);
+
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/Routes.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/Routes.java
@@ -134,7 +134,7 @@ public class Routes {
         return value == null || value.isBlank();
     }
 
-    private Long extractInstallationId(JsonObject body) {
+    public Long extractInstallationId(JsonObject body) {
         Long installationId;
 
         JsonObject installation = body.getJsonObject("installation");

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubService.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubService.java
@@ -18,13 +18,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import io.quarkiverse.githubapp.GitHubClientProvider;
 import io.quarkiverse.githubapp.runtime.config.GitHubAppRuntimeConfig;
 import io.quarkiverse.githubapp.runtime.signing.JwtTokenCreator;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClientBuilder;
 
 @ApplicationScoped
-public class GitHubService {
+public class GitHubService implements GitHubClientProvider {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String AUTHORIZATION_HEADER_BEARER = "Bearer %s";
@@ -68,7 +69,8 @@ public class GitHubService {
                 .build(new CreateInstallationToken());
     }
 
-    public GitHub getInstallationClient(Long installationId) {
+    @Override
+    public GitHub getInstallationClient(long installationId) {
         try {
             return createInstallationClient(installationId);
         } catch (IOException e1) {
@@ -90,7 +92,8 @@ public class GitHubService {
         }
     }
 
-    public DynamicGraphQLClient getInstallationGraphQLClient(Long installationId) {
+    @Override
+    public DynamicGraphQLClient getInstallationGraphQLClient(long installationId) {
         try {
             return createInstallationGraphQLClient(installationId);
         } catch (IOException | ExecutionException | InterruptedException e1) {
@@ -112,7 +115,7 @@ public class GitHubService {
         }
     }
 
-    private GitHub createInstallationClient(Long installationId) throws IOException {
+    private GitHub createInstallationClient(long installationId) throws IOException {
         CachedInstallationToken installationToken = installationTokenCache.get(installationId);
 
         final GitHubBuilder gitHubBuilder = new GitHubBuilder()
@@ -127,7 +130,7 @@ public class GitHubService {
         return gitHub;
     }
 
-    private DynamicGraphQLClient createInstallationGraphQLClient(Long installationId)
+    private DynamicGraphQLClient createInstallationGraphQLClient(long installationId)
             throws IOException, ExecutionException, InterruptedException {
         CachedInstallationToken installationToken = installationTokenCache.get(installationId);
 
@@ -167,6 +170,11 @@ public class GitHubService {
     }
 
     // TODO even if we have a cache for the other one, we should probably also keep this one around for a few minutes
+    @Override
+    public GitHub getApplicationClient() {
+        return createApplicationGitHub();
+    }
+
     private GitHub createApplicationGitHub() {
         String jwtToken;
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/EventContextSpecification.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/EventContextSpecification.java
@@ -4,4 +4,6 @@ public interface EventContextSpecification {
     <T extends Throwable> EventContextSpecification github(GitHubMockSetup<T> gitHubMockSetup) throws T;
 
     EventSenderOptions when();
+
+    <T extends Throwable> EventHandlingResponse when(TestedAction<T> action) throws T;
 }

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
@@ -8,13 +8,30 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHTeam;
 import org.kohsuke.github.GitHub;
 
+import io.quarkiverse.githubapp.GitHubClientProvider;
 import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public interface GitHubMockContext {
 
-    GitHub client(long id);
+    /**
+     * @return The mock for the application client.
+     * @see GitHubClientProvider#getApplicationClient()
+     */
+    GitHub applicationClient();
 
-    DynamicGraphQLClient graphQLClient(long id);
+    /**
+     * @param installationId The identifier of the GitHub app installation.
+     * @return The mock for the installation client.
+     * @see GitHubClientProvider#getInstallationClient(long)
+     */
+    GitHub client(long installationId);
+
+    /**
+     * @param installationId The identifier of the GitHub app installation.
+     * @return The mock for the installation GraphQL client.
+     * @see GitHubClientProvider#getInstallationGraphQLClient(long)
+     */
+    DynamicGraphQLClient graphQLClient(long installationId);
 
     GHRepository repository(String id);
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
@@ -24,14 +24,38 @@ public interface GitHubMockContext {
      * @return The mock for the installation client.
      * @see GitHubClientProvider#getInstallationClient(long)
      */
-    GitHub client(long installationId);
+    GitHub installationClient(long installationId);
+
+    /**
+     * @param installationId The identifier of the GitHub app installation.
+     * @return The mock for the installation client.
+     * @see GitHubClientProvider#getInstallationClient(long)
+     * @deprecated Use {@link #installationClient(long)} instead.
+     *             This method will be removed in version 2 of this extension.
+     */
+    @Deprecated(forRemoval = true)
+    default GitHub client(long installationId) {
+        return installationClient(installationId);
+    }
 
     /**
      * @param installationId The identifier of the GitHub app installation.
      * @return The mock for the installation GraphQL client.
      * @see GitHubClientProvider#getInstallationGraphQLClient(long)
      */
-    DynamicGraphQLClient graphQLClient(long installationId);
+    DynamicGraphQLClient installationGraphQLClient(long installationId);
+
+    /**
+     * @param installationId The identifier of the GitHub app installation.
+     * @return The mock for the installation GraphQL client.
+     * @see GitHubClientProvider#getInstallationGraphQLClient(long)
+     * @deprecated Use {@link #installationGraphQLClient(long)} instead.
+     *             This method will be removed in version 2 of this extension.
+     */
+    @Deprecated(forRemoval = true)
+    default DynamicGraphQLClient graphQLClient(long installationId) {
+        return installationGraphQLClient(installationId);
+    }
 
     GHRepository repository(String id);
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/TestedAction.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/TestedAction.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.githubapp.testing.dsl;
+
+@FunctionalInterface
+public interface TestedAction<T extends Throwable> {
+
+    void run() throws T;
+
+}

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/EventContextSpecificationImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/EventContextSpecificationImpl.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubapp.testing.internal;
 
 import io.quarkiverse.githubapp.testing.dsl.EventContextSpecification;
 import io.quarkiverse.githubapp.testing.dsl.GitHubMockSetup;
+import io.quarkiverse.githubapp.testing.dsl.TestedAction;
 
 public final class EventContextSpecificationImpl implements EventContextSpecification {
     private final GitHubAppTestingContext testingContext;
@@ -23,4 +24,9 @@ public final class EventContextSpecificationImpl implements EventContextSpecific
         return new EventSenderOptionsImpl(testingContext);
     }
 
+    @Override
+    public <T extends Throwable> EventHandlingResponseImpl when(TestedAction<T> action) throws T {
+        action.run();
+        return new EventHandlingResponseImpl(testingContext);
+    }
 }

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -74,7 +74,7 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     }
 
     @Override
-    public GitHub client(long installationId) {
+    public GitHub installationClient(long installationId) {
         return applicationOrInstallationClient(installationId);
     }
 
@@ -84,7 +84,7 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     }
 
     @Override
-    public DynamicGraphQLClient graphQLClient(long installationId) {
+    public DynamicGraphQLClient installationGraphQLClient(long installationId) {
         return graphQLClients.getOrCreate(installationId)
                 .mock();
     }
@@ -151,14 +151,14 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
                 .thenAnswer(invocation -> applicationClient());
 
         when(service.getInstallationClient(anyLong()))
-                .thenAnswer(invocation -> client(invocation.getArgument(0, Long.class)));
+                .thenAnswer(invocation -> installationClient(invocation.getArgument(0, Long.class)));
 
         when(service.getInstallationGraphQLClient(anyLong()))
-                .thenAnswer(invocation -> graphQLClient(invocation.getArgument(0, Long.class)));
+                .thenAnswer(invocation -> installationGraphQLClient(invocation.getArgument(0, Long.class)));
     }
 
     void initEventStubs(long installationId) {
-        GitHub clientMock = client(installationId);
+        GitHub clientMock = installationClient(installationId);
         MockitoUtils.doWithMockedClassClassLoader(GitHub.class, () -> {
             try {
                 when(clientMock.parseEventPayload(any(), any())).thenAnswer(invocation -> {

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.githubapp.testing.internal;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -152,10 +153,10 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     void init() {
         reset();
 
-        when(service.getInstallationClient(any()))
+        when(service.getInstallationClient(anyLong()))
                 .thenAnswer(invocation -> client(invocation.getArgument(0, Long.class)));
 
-        when(service.getInstallationGraphQLClient(any()))
+        when(service.getInstallationGraphQLClient(anyLong()))
                 .thenAnswer(invocation -> graphQLClient(invocation.getArgument(0, Long.class)));
     }
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/MockitoUtils.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/MockitoUtils.java
@@ -7,6 +7,13 @@ public class MockitoUtils {
     private MockitoUtils() {
     }
 
+    public static void doWithMockedClassClassLoader(Class<?> mockedClass, Runnable action) {
+        doWithMockedClassClassLoader(mockedClass, () -> {
+            action.run();
+            return null;
+        });
+    }
+
     public static <T> T doWithMockedClassClassLoader(Class<?> mockedClass, Supplier<T> action) {
         ClassLoader mockedClassClassLoader = mockedClass.getClassLoader();
         ClassLoader old = Thread.currentThread().getContextClassLoader();

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/mockito/internal/GitHubMockDefaultAnswer.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/mockito/internal/GitHubMockDefaultAnswer.java
@@ -2,8 +2,9 @@ package io.quarkiverse.githubapp.testing.mockito.internal;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.function.Function;
 
-import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -11,25 +12,41 @@ import org.mockito.stubbing.Answer;
 /**
  * The default answer for all {@link GitHub} mocks.
  * <p>
- * The purpose of this default answer is to control the behavior of package-protected methods
- * such as {@code GitHub#intern(GHUser)},
- * without relying on external help such as Powermock.
+ * The purpose of this default answer is to control the behavior of a few special methods:
+ * <ul>
+ * <li>package-protected methods such as {@code GitHub#intern(GHUser)},
+ * whose stubbing would normally require relying on external help such as Powermock.</li>
+ * <li>other methods that need to be stubbed but cannot,
+ * because they are not guaranteed to be called and thus might trigger an
+ * {@link org.mockito.exceptions.misusing.UnnecessaryStubbingException}
+ * in {@link org.mockito.Mock.Strictness#STRICT_STUBS} mode.
+ * (example: {@link GitHub#isOffline()})</li>
+ * </ul>
  */
 public final class GitHubMockDefaultAnswer implements Answer<Object>, Serializable {
 
     private final Answer<Object> delegate;
+    private final Function<String, GHRepository> repositoryMockProvider;
 
-    public GitHubMockDefaultAnswer(Answer<Object> delegate) {
+    public GitHubMockDefaultAnswer(Answer<Object> delegate, Function<String, GHRepository> repositoryMockProvider) {
         this.delegate = delegate;
+        this.repositoryMockProvider = repositoryMockProvider;
     }
 
     @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
         Method method = invocation.getMethod();
-        if (method.getParameterCount() == 1 && method.getName().equals("intern")) {
-            return invocation.callRealMethod();
-        } else {
-            return delegate.answer(invocation);
+        if (method.getParameterCount() == 1) {
+            switch (method.getName()) {
+                case "intern":
+                    return invocation.callRealMethod();
+                case "isOffline":
+                    // Stubbed GitHub clients are always offline
+                    return true;
+                case "getRepository":
+                    return repositoryMockProvider.apply(invocation.getArgument(0, String.class));
+            }
         }
+        return delegate.answer(invocation);
     }
 }

--- a/testing/src/test/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImplEventMocksTest.java
+++ b/testing/src/test/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImplEventMocksTest.java
@@ -35,6 +35,7 @@ public class GitHubMockContextImplEventMocksTest {
     @BeforeEach
     public void init() {
         context.init();
+        context.initEventStubs(123);
         client = context.client(123);
     }
 

--- a/testing/src/test/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImplEventMocksTest.java
+++ b/testing/src/test/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImplEventMocksTest.java
@@ -36,7 +36,7 @@ public class GitHubMockContextImplEventMocksTest {
     public void init() {
         context.init();
         context.initEventStubs(123);
-        client = context.client(123);
+        client = context.installationClient(123);
     }
 
     @Test


### PR DESCRIPTION
This adds `GitHubClientProvider`, to expose the GitHub clients to apps, so that they can access it even when not processing an event (e.g. when doing background processing).

Note most of the complexity/changes are in the second commit and are related to the testing framework, in order to enable mocking clients and GHObjects even when not processing an event.