### PR TITLE
Expose config file retrieval through a service

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/githubapp/deployment/GitHubAppProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/githubapp/deployment/GitHubAppProcessor.java
@@ -58,10 +58,10 @@ import io.quarkiverse.githubapp.deployment.DispatchingConfiguration.EventDispatc
 import io.quarkiverse.githubapp.deployment.DispatchingConfiguration.EventDispatchingMethod;
 import io.quarkiverse.githubapp.error.ErrorHandler;
 import io.quarkiverse.githubapp.event.Actions;
-import io.quarkiverse.githubapp.runtime.ConfigFileReader;
 import io.quarkiverse.githubapp.runtime.GitHubAppRecorder;
 import io.quarkiverse.githubapp.runtime.MultiplexedEvent;
 import io.quarkiverse.githubapp.runtime.Multiplexer;
+import io.quarkiverse.githubapp.runtime.RequestScopeCachingGitHubConfigFileProvider;
 import io.quarkiverse.githubapp.runtime.error.DefaultErrorHandler;
 import io.quarkiverse.githubapp.runtime.error.ErrorHandlerBridgeFunction;
 import io.quarkiverse.githubapp.runtime.github.GitHubFileDownloader;
@@ -676,7 +676,7 @@ class GitHubAppProcessor {
                     j++;
                 }
                 if (originalMethod.hasAnnotation(CONFIG_FILE)) {
-                    parameterTypes.add(ConfigFileReader.class.getName());
+                    parameterTypes.add(RequestScopeCachingGitHubConfigFileProvider.class.getName());
                 }
 
                 MethodCreator methodCreator = multiplexerClassCreator.getMethodCreator(
@@ -767,7 +767,8 @@ class GitHubAppProcessor {
                                 .ofMethod(PayloadHelper.class, "getRepository", GHRepository.class, GHEventPayload.class),
                                 payloadRh);
                         ResultHandle configObject = tryBlock.invokeVirtualMethod(
-                                MethodDescriptor.ofMethod(ConfigFileReader.class, "getConfigObject", Object.class,
+                                MethodDescriptor.ofMethod(RequestScopeCachingGitHubConfigFileProvider.class, "getConfigObject",
+                                        Object.class,
                                         GHRepository.class, String.class, ConfigFile.Source.class, Class.class),
                                 configFileReaderRh,
                                 ghRepositoryRh,

--- a/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/ConfigFileProviderCliTest.java
+++ b/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/ConfigFileProviderCliTest.java
@@ -13,7 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @GitHubAppTest
-public class ConfigFileReaderCliTest {
+public class ConfigFileProviderCliTest {
 
     public static final String HELLO = "hello from config file reader";
 

--- a/integration-tests/testing-framework/src/main/java/io/quarkiverse/githubapp/it/testingframework/BackgroundProcessor.java
+++ b/integration-tests/testing-framework/src/main/java/io/quarkiverse/githubapp/it/testingframework/BackgroundProcessor.java
@@ -6,6 +6,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import io.quarkiverse.githubapp.GitHubClientProvider;
+import io.quarkiverse.githubapp.GitHubConfigFileProvider;
 
 @ApplicationScoped
 public class BackgroundProcessor {
@@ -15,11 +16,14 @@ public class BackgroundProcessor {
     @Inject
     GitHubClientProvider clientProvider;
 
+    @Inject
+    GitHubConfigFileProvider configFileProvider;
+
     public void process() throws IOException {
-        behavior.execute(clientProvider);
+        behavior.execute(clientProvider, configFileProvider);
     }
 
     public interface Behavior {
-        void execute(GitHubClientProvider clientProvider) throws IOException;
+        void execute(GitHubClientProvider clientProvider, GitHubConfigFileProvider configFileProvider) throws IOException;
     }
 }

--- a/integration-tests/testing-framework/src/main/java/io/quarkiverse/githubapp/it/testingframework/config/MyConfigFile.java
+++ b/integration-tests/testing-framework/src/main/java/io/quarkiverse/githubapp/it/testingframework/config/MyConfigFile.java
@@ -1,7 +1,39 @@
 package io.quarkiverse.githubapp.it.testingframework.config;
 
+import java.util.Objects;
+
 public class MyConfigFile {
 
     public String someProperty;
+
+    public MyConfigFile() {
+
+    }
+
+    public MyConfigFile(String someProperty) {
+        this.someProperty = someProperty;
+    }
+
+    @Override
+    public String toString() {
+        return "MyConfigFile{" +
+                "someProperty='" + someProperty + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MyConfigFile that = (MyConfigFile) o;
+        return Objects.equals(someProperty, that.someProperty);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(someProperty, someProperty);
+    }
 
 }

--- a/integration-tests/testing-framework/src/test/java/io/quarkiverse/githubapp/it/testingframework/TestingFrameworkTest.java
+++ b/integration-tests/testing-framework/src/test/java/io/quarkiverse/githubapp/it/testingframework/TestingFrameworkTest.java
@@ -52,7 +52,7 @@ public class TestingFrameworkTest {
                 .event(GHEvent.ISSUES)
                 .then().github(mocks -> {
                 }))
-                .doesNotThrowAnyException();
+                        .doesNotThrowAnyException();
         assertThat(capture[0]).isEqualTo("someValue");
     }
 
@@ -153,9 +153,9 @@ public class TestingFrameworkTest {
                             .addLabels("someValue");
                     verifyNoMoreInteractions(mocks.ghObjects());
                 }))
-                .hasMessageContaining("The event handler threw an exception:")
-                .hasMessageEndingWith("null")
-                .hasStackTraceContaining("at org.kohsuke.github.GHIssue.getComments");
+                        .hasMessageContaining("The event handler threw an exception:")
+                        .hasMessageEndingWith("null")
+                        .hasStackTraceContaining("at org.kohsuke.github.GHIssue.getComments");
     }
 
     @Test
@@ -182,7 +182,7 @@ public class TestingFrameworkTest {
         assertThatCode(() -> given()
                 .when().payloadFromClasspath("/pr-opened-dependabot.json")
                 .event(GHEvent.PULL_REQUEST))
-                .doesNotThrowAnyException();
+                        .doesNotThrowAnyException();
         assertThat(capture[0]).isEqualTo("dependabot[bot]");
     }
 
@@ -197,11 +197,11 @@ public class TestingFrameworkTest {
                 for (GHRepository repository : installation.listRepositories()) {
                     GitHub installationClient = clientProvider.getInstallationClient(installation.getId());
                     // Get the repository with enhanced permissions thanks to the installation client.
-                    repository = installationClient.getRepository(repository.getName());
+                    repository = installationClient.getRepository(repository.getFullName());
                     // Simulate doing stuff with the repository.
                     // Normally that stuff would require enhanced permissions,
                     // but here's we're just calling getFullName() to simplify.
-                    capture.add(repository.getFullName());
+                    capture.add(repository.getSshUrl());
                 }
             }
         };
@@ -222,13 +222,13 @@ public class TestingFrameworkTest {
                             installation2);
                     Mockito.when(app.listInstallations()).thenReturn(appInstallations);
 
-                    Mockito.when(installation1Repo1.getName()).thenReturn("quarkus");
+                    Mockito.when(installation1Repo1.getFullName()).thenReturn("quarkusio/quarkus");
                     PagedSearchIterable<GHRepository> installation1Repos = MockHelper.mockPagedIterable(installation1Repo1);
                     Mockito.when(installation1.listRepositories())
                             .thenReturn(installation1Repos);
 
-                    Mockito.when(installation2Repo1.getName()).thenReturn("quarkus-github-app");
-                    Mockito.when(installation2Repo2.getName()).thenReturn("quarkus-github-api");
+                    Mockito.when(installation2Repo1.getFullName()).thenReturn("quarkiverse/quarkus-github-app");
+                    Mockito.when(installation2Repo2.getFullName()).thenReturn("quarkiverse/quarkus-github-api");
                     PagedSearchIterable<GHRepository> installation2Repos = MockHelper.mockPagedIterable(installation2Repo1,
                             installation2Repo2);
                     Mockito.when(installation2.listRepositories())
@@ -236,11 +236,12 @@ public class TestingFrameworkTest {
 
                     // Installation clients will return different Repository objects than the application client:
                     // that's expected.
-                    Mockito.when(mocks.repository("quarkus").getFullName()).thenReturn("quarkusio/quarkus");
-                    Mockito.when(mocks.repository("quarkus-github-app").getFullName())
-                            .thenReturn("quarkiverse/quarkus-github-app");
-                    Mockito.when(mocks.repository("quarkus-github-api").getFullName())
-                            .thenReturn("quarkiverse/quarkus-github-api");
+                    Mockito.when(mocks.repository("quarkusio/quarkus").getSshUrl())
+                            .thenReturn("ssh://github.com/quarkusio/quarkus.git");
+                    Mockito.when(mocks.repository("quarkiverse/quarkus-github-app").getSshUrl())
+                            .thenReturn("ssh://github.com/quarkiverse/quarkus-github-app");
+                    Mockito.when(mocks.repository("quarkiverse/quarkus-github-api").getSshUrl())
+                            .thenReturn("ssh://github.com/quarkiverse/quarkus-github-api");
                 })
                 .when(backgroundProcessor::process)
                 .then().github(mocks -> {
@@ -248,11 +249,11 @@ public class TestingFrameworkTest {
                             installation2Repo2);
                     Mockito.verifyNoMoreInteractions(mocks.ghObjects());
                 }))
-                .doesNotThrowAnyException();
+                        .doesNotThrowAnyException();
         assertThat(capture).containsExactlyInAnyOrder(
-                "quarkusio/quarkus",
-                "quarkiverse/quarkus-github-app",
-                "quarkiverse/quarkus-github-api");
+                "ssh://github.com/quarkusio/quarkus.git",
+                "ssh://github.com/quarkiverse/quarkus-github-app.git",
+                "ssh://github.com/quarkiverse/quarkus-github-api.git");
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/githubapp/ConfigFile.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/ConfigFile.java
@@ -6,17 +6,53 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Marks a parameter as a configuration file to be fetched from the code repository,
+ * and optionally (if the parameter type is different from {@link String})
+ * deserialized using Jackson.
+ * <p>
+ * Configuration files are always retrieved from the default branch,
+ * but there is some flexibility as to which repository the files are retrieved from
+ * in the case of forks, see {@link #source()}.
+ */
 @Target(PARAMETER)
 @Retention(RUNTIME)
 public @interface ConfigFile {
 
+    /**
+     * @return The path to the file in the code repository,
+     * either absolute (if it starts with {@code /}) or relative to {@code /.github/} (if it doesn't start with {@code /}).
+     */
     String value();
 
+    /**
+     * @return Which repository to extract the file from in the case of forked repositories.
+     * @see Source
+     */
     Source source() default Source.DEFAULT;
 
-    public enum Source {
+    /**
+     * Which repository to extract a configuration file from.
+     */
+    enum Source {
+        /**
+         * Default behavior:
+         * <ul>
+         *     <li>If {@code quarkus.github-app.read-config-files-from-source-repository}
+         *     is unset or set to {@code false}, behaves as {@link #CURRENT_REPOSITORY}</li>
+         *     <li>If {@code quarkus.github-app.read-config-files-from-source-repository}
+         *     is set to {@code true}, behaves as {@link #SOURCE_REPOSITORY}</li>
+         * </ul>
+         */
         DEFAULT,
+        /**
+         * Always retrieve the configuration file from the "source" (non-fork) repository;
+         * in the case of forks, the configuration file living in the fork will be ignored.
+         */
         SOURCE_REPOSITORY,
+        /**
+         * Always retrieve the configuration file from the repository from which an event was sent.
+         */
         CURRENT_REPOSITORY;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/githubapp/ConfigFile.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/ConfigFile.java
@@ -21,7 +21,8 @@ public @interface ConfigFile {
 
     /**
      * @return The path to the file in the code repository,
-     * either absolute (if it starts with {@code /}) or relative to {@code /.github/} (if it doesn't start with {@code /}).
+     *         either absolute (if it starts with {@code /}) or relative to {@code /.github/} (if it doesn't start with
+     *         {@code /}).
      */
     String value();
 
@@ -38,10 +39,10 @@ public @interface ConfigFile {
         /**
          * Default behavior:
          * <ul>
-         *     <li>If {@code quarkus.github-app.read-config-files-from-source-repository}
-         *     is unset or set to {@code false}, behaves as {@link #CURRENT_REPOSITORY}</li>
-         *     <li>If {@code quarkus.github-app.read-config-files-from-source-repository}
-         *     is set to {@code true}, behaves as {@link #SOURCE_REPOSITORY}</li>
+         * <li>If {@code quarkus.github-app.read-config-files-from-source-repository}
+         * is unset or set to {@code false}, behaves as {@link #CURRENT_REPOSITORY}</li>
+         * <li>If {@code quarkus.github-app.read-config-files-from-source-repository}
+         * is set to {@code true}, behaves as {@link #SOURCE_REPOSITORY}</li>
          * </ul>
          */
         DEFAULT,

--- a/runtime/src/main/java/io/quarkiverse/githubapp/GitHubConfigFileProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/GitHubConfigFileProvider.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.githubapp;
+
+import java.util.Optional;
+
+import org.kohsuke.github.GHRepository;
+
+/**
+ * A provider of configuration files fetched from {@link org.kohsuke.github.GHRepository GitHub repositories}.
+ * <p>
+ * Inject as a CDI bean.
+ * <p>
+ * <strong>NOTE:</strong> You generally will not need this bean when processing events,
+ * as configuration files can be automatically injected into event listener methods,
+ * simply by annotating a parameter with {@link ConfigFile}.
+ * This provider is mostly useful for non-event use cases (e.g. cron jobs).
+ *
+ * @see ConfigFile
+ * @see ConfigFile.Source
+ */
+public interface GitHubConfigFileProvider {
+
+    /**
+     * Fetches the configuration file at the given path from the main branch of the given repository,
+     * optionally (if {@code type} is not just {@link String}) deserializing it to the given type using Jackson.
+     * <p>
+     * <strong>NOTE:</strong> You generally will not need this method when processing events,
+     * as configuration files can be automatically injected into event listener methods,
+     * simply by annotating a parameter with {@link ConfigFile}.
+     * This provider is mostly useful for non-event use cases (e.g. cron jobs).
+     *
+     * @param repository The GitHub code repository to retrieve the file from.
+     * @param path The path to the file in the code repository,
+     *        either absolute (if it starts with {@code /}) or relative to {@code /.github/} (if it doesn't start with
+     *        {@code /}).
+     * @param source Which repository to extract the file from in the case of forked repositories.
+     * @param type The type to deserialize the file to.
+     * @return The configuration file wrapped in an {@link java.util.Optional}, or {@link Optional#empty()} if it is missing.
+     * @throws java.io.IOException If the configuration file cannot be retrieved.
+     * @throws IllegalStateException If the configuration file cannot be deserialized to the given type.
+     * @see ConfigFile
+     * @see ConfigFile.Source
+     */
+    <T> Optional<T> fetchConfigFile(GHRepository repository, String path, ConfigFile.Source source, Class<T> type);
+
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/GitHubConfigFileProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/GitHubConfigFileProvider.java
@@ -42,4 +42,28 @@ public interface GitHubConfigFileProvider {
      */
     <T> Optional<T> fetchConfigFile(GHRepository repository, String path, ConfigFile.Source source, Class<T> type);
 
+    /**
+     * Fetches the configuration file at the given path from the given ref of the given repository,
+     * optionally (if {@code type} is not just {@link String}) deserializing it to the given type using Jackson.
+     * <p>
+     * <strong>NOTE:</strong> You generally will not need this method when processing events,
+     * as configuration files can be automatically injected into event listener methods,
+     * simply by annotating a parameter with {@link ConfigFile}.
+     * This provider is mostly useful for non-event use cases (e.g. cron jobs).
+     *
+     * @param repository The GitHub code repository to retrieve the file from.
+     * @param ref The git ref (branch, commit SHA, ...) to retrieve the file from.
+     * @param path The path to the file in the code repository,
+     *        either absolute (if it starts with {@code /}) or relative to {@code /.github/} (if it doesn't start with
+     *        {@code /}).
+     * @param source Which repository to extract the file from in the case of forked repositories.
+     * @param type The type to deserialize the file to.
+     * @return The configuration file wrapped in an {@link java.util.Optional}, or {@link Optional#empty()} if it is missing.
+     * @throws java.io.IOException If the configuration file cannot be retrieved.
+     * @throws IllegalStateException If the configuration file cannot be deserialized to the given type.
+     * @see ConfigFile
+     * @see ConfigFile.Source
+     */
+    <T> Optional<T> fetchConfigFile(GHRepository repository, String ref, String path, ConfigFile.Source source, Class<T> type);
+
 }

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/RequestScopeCachingGitHubConfigFileProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/RequestScopeCachingGitHubConfigFileProvider.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.githubapp.runtime;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.kohsuke.github.GHRepository;
+
+import io.quarkiverse.githubapp.ConfigFile;
+import io.quarkiverse.githubapp.GitHubConfigFileProvider;
+import io.quarkiverse.githubapp.runtime.config.GitHubAppRuntimeConfig;
+import io.quarkiverse.githubapp.runtime.github.GitHubConfigFileProviderImpl;
+
+@RequestScoped
+public class RequestScopeCachingGitHubConfigFileProvider {
+
+    @Inject
+    GitHubAppRuntimeConfig gitHubAppRuntimeConfig;
+
+    @Inject
+    GitHubConfigFileProvider gitHubConfigFileProvider;
+
+    private final Map<String, Object> cache = new ConcurrentHashMap<>();
+
+    public Object getConfigObject(GHRepository ghRepository, String path, ConfigFile.Source source, Class<?> type) {
+        String cacheKey = getCacheKey(ghRepository, path, source);
+
+        Object cachedObject = cache.get(cacheKey);
+        if (cachedObject != null) {
+            return cachedObject;
+        }
+
+        return cache.computeIfAbsent(cacheKey,
+                k -> gitHubConfigFileProvider.fetchConfigFile(ghRepository, path, source, type).orElse(null));
+    }
+
+    private String getCacheKey(GHRepository ghRepository, String path,
+            ConfigFile.Source source) {
+        String fullPath = GitHubConfigFileProviderImpl.getFilePath(path.trim());
+        ConfigFile.Source effectiveSource = gitHubAppRuntimeConfig.getEffectiveSource(source);
+        // we should only handle the config files of one repository in a given ConfigFileReader
+        // as it's request scoped but let's be on the safe side
+        return ghRepository.getFullName() + ":" + effectiveSource.name() + ":" + fullPath;
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/GitHubAppRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/GitHubAppRuntimeConfig.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.util.Optional;
 
+import io.quarkiverse.githubapp.ConfigFile;
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -69,6 +70,14 @@ public class GitHubAppRuntimeConfig {
      */
     @ConfigItem
     public Debug debug;
+
+    public ConfigFile.Source getEffectiveSource(ConfigFile.Source source) {
+        if (source == ConfigFile.Source.DEFAULT) {
+            return readConfigFilesFromSourceRepository ? ConfigFile.Source.SOURCE_REPOSITORY
+                    : ConfigFile.Source.CURRENT_REPOSITORY;
+        }
+        return source;
+    }
 
     @ConfigGroup
     public static class Debug {

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubConfigFileProviderImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubConfigFileProviderImpl.java
@@ -45,11 +45,17 @@ public class GitHubConfigFileProviderImpl implements GitHubConfigFileProvider {
 
     @Override
     public <T> Optional<T> fetchConfigFile(GHRepository repository, String path, ConfigFile.Source source, Class<T> type) {
+        return fetchConfigFile(repository, null, path, source, type);
+    }
+
+    @Override
+    public <T> Optional<T> fetchConfigFile(GHRepository repository, String ref, String path, ConfigFile.Source source,
+            Class<T> type) {
         GHRepository configGHRepository = getConfigRepository(repository, source, path);
 
         String fullPath = getFilePath(path);
 
-        Optional<String> contentOptional = gitHubFileDownloader.getFileContent(configGHRepository, fullPath);
+        Optional<String> contentOptional = gitHubFileDownloader.getFileContent(configGHRepository, ref, fullPath);
         if (contentOptional.isEmpty()) {
             return Optional.empty();
         }

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubFileDownloader.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubFileDownloader.java
@@ -22,7 +22,7 @@ public class GitHubFileDownloader {
     LaunchMode launchMode;
 
     @SuppressWarnings("deprecation")
-    public Optional<String> getFileContent(GHRepository ghRepository, String fullPath) {
+    public Optional<String> getFileContent(GHRepository ghRepository, String ref, String fullPath) {
         try {
             GHContent ghContent = ghRepository.getFileContent(fullPath);
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockConfigFileSetupContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockConfigFileSetupContext.java
@@ -2,7 +2,22 @@ package io.quarkiverse.githubapp.testing.dsl;
 
 import java.io.IOException;
 
+import org.kohsuke.github.GHRepository;
+
+import io.quarkiverse.githubapp.ConfigFile;
+
 public interface GitHubMockConfigFileSetupContext {
+
+    /**
+     * Mocks the retrieval of particular ref.
+     *
+     * @param ref The ref passed to
+     *        {@link io.quarkiverse.githubapp.GitHubConfigFileProvider#fetchConfigFile(GHRepository, String, String, ConfigFile.Source, Class)}
+     * @return {@code this}, to continue mocking setup.
+     * @see io.quarkiverse.githubapp.GitHubConfigFileProvider#fetchConfigFile(GHRepository, String, String, ConfigFile.Source,
+     *      Class)
+     */
+    GitHubMockConfigFileSetupContext withRef(String ref);
 
     /**
      * Finalizes mocking, using a file from the classpath as stubbed content.

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockConfigFileSetupContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockConfigFileSetupContext.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.githubapp.testing.dsl;
+
+import java.io.IOException;
+
+public interface GitHubMockConfigFileSetupContext {
+
+    /**
+     * Finalizes mocking, using a file from the classpath as stubbed content.
+     *
+     * @param pathInClasspath The path of the content to use in the classpath.
+     * @throws IOException If reading the content from the classpath fails.
+     */
+    void fromClasspath(String pathInClasspath) throws IOException;
+
+    /**
+     * Finalizes mocking, using a given string as stubbed content.
+     *
+     * @param configFile The content of the configuration file as a string.
+     */
+    void fromString(String configFile);
+
+}

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockContext.java
@@ -57,7 +57,11 @@ public interface GitHubMockContext {
         return installationGraphQLClient(installationId);
     }
 
-    GHRepository repository(String id);
+    /**
+     * @param fullName The full name of a GitHub repository, for instance {@code quarkusio/quarkus}.
+     * @return The mock for that repository.
+     */
+    GHRepository repository(String fullName);
 
     GHIssue issue(long id);
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockSetupContext.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/GitHubMockSetupContext.java
@@ -2,10 +2,61 @@ package io.quarkiverse.githubapp.testing.dsl;
 
 import java.io.IOException;
 
+import org.kohsuke.github.GHRepository;
+
+import io.quarkiverse.githubapp.ConfigFile;
+
 public interface GitHubMockSetupContext extends GitHubMockContext {
 
-    void configFileFromClasspath(String pathInRepository, String pathInClassPath) throws IOException;
+    /**
+     * Mocks the fetching of a configuration file from the GitHub repository of an event,
+     * using a file from the classpath as stubbed content.
+     *
+     * @param pathInRepository The path of the file passed to {@link ConfigFile#value()}.
+     * @param pathInClasspath The path of the content to use in the classpath.
+     * @throws IOException If reading the content from the classpath fails.
+     * @see ConfigFile
+     * @deprecated Call {@code configFile(pathInRepository).fromClasspath(pathInClassPath)} instead.
+     *             Will be removed in version 2 of this extension.
+     */
+    @Deprecated(forRemoval = true)
+    default void configFileFromClasspath(String pathInRepository, String pathInClasspath) throws IOException {
+        configFile(pathInRepository).fromClasspath(pathInClasspath);
+    }
 
-    void configFileFromString(String pathInRepository, String configFile);
+    /**
+     * Mocks the fetching of a configuration file from the GitHub repository of an event,
+     * using a given string as stubbed content.
+     *
+     * @param pathInRepository The path of the file passed to {@link ConfigFile#value()}.
+     * @param configFile The content of the configuration file as a string.
+     * @see ConfigFile
+     * @deprecated Call {@code configFile(pathInRepository).fromString(configFile)} instead.
+     *             Will be removed in version 2 of this extension.
+     */
+    @Deprecated
+    default void configFileFromString(String pathInRepository, String configFile) {
+        configFile(pathInRepository).fromString(configFile);
+    }
+
+    /**
+     * Starts mocking the fetching of a configuration file from the GitHub repository of an event.
+     *
+     * @param pathInRepository The path of the file passed to {@link ConfigFile#value()}.
+     * @return A context to set the stubbed content of the file.
+     * @see ConfigFile
+     */
+    GitHubMockConfigFileSetupContext configFile(String pathInRepository);
+
+    /**
+     * Starts mocking the fetching of a configuration file from a given GitHub repository mock.
+     *
+     * @param repository The repository mock, generally retrieved from {@link #repository(String)}.
+     * @param pathInRepository The path of the file passed to
+     *        {@link io.quarkiverse.githubapp.GitHubConfigFileProvider#fetchConfigFile(GHRepository, String, ConfigFile.Source, Class)}.
+     * @see GitHubMockContext#repository(String)
+     * @see io.quarkiverse.githubapp.GitHubConfigFileProvider#fetchConfigFile(GHRepository, String, ConfigFile.Source, Class)
+     */
+    GitHubMockConfigFileSetupContext configFile(GHRepository repository, String pathInRepository);
 
 }

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -3,6 +3,7 @@ package io.quarkiverse.githubapp.testing.internal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -100,6 +101,15 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     @Override
     public GitHubMockConfigFileSetupContext configFile(GHRepository repository, String pathInRepository) {
         return new GitHubMockConfigFileSetupContext() {
+
+            private String ref;
+
+            @Override
+            public GitHubMockConfigFileSetupContext withRef(String ref) {
+                this.ref = ref;
+                return this;
+            }
+
             @Override
             public void fromClasspath(String pathInClasspath) throws IOException {
                 fromString(GitHubAppTestingContext.get().getFromClasspath(pathInClasspath));
@@ -108,7 +118,7 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
             @Override
             public void fromString(String configFile) {
                 when(fileDownloader.getFileContent(repository == null ? any() : same(repository),
-                        eq(GitHubConfigFileProviderImpl.getFilePath(pathInRepository))))
+                        ref == null ? isNull() : eq(ref), eq(GitHubConfigFileProviderImpl.getFilePath(pathInRepository))))
                         .thenReturn(Optional.of(configFile));
             }
         };

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -3,6 +3,7 @@ package io.quarkiverse.githubapp.testing.internal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -33,6 +34,7 @@ import org.mockito.Mockito;
 import io.quarkiverse.githubapp.runtime.github.GitHubConfigFileProviderImpl;
 import io.quarkiverse.githubapp.runtime.github.GitHubFileDownloader;
 import io.quarkiverse.githubapp.runtime.github.GitHubService;
+import io.quarkiverse.githubapp.testing.dsl.GitHubMockConfigFileSetupContext;
 import io.quarkiverse.githubapp.testing.dsl.GitHubMockContext;
 import io.quarkiverse.githubapp.testing.dsl.GitHubMockSetupContext;
 import io.quarkiverse.githubapp.testing.dsl.GitHubMockVerificationContext;
@@ -91,14 +93,25 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     }
 
     @Override
-    public void configFileFromClasspath(String pathInRepository, String pathInClassPath) throws IOException {
-        configFileFromString(pathInRepository, GitHubAppTestingContext.get().getFromClasspath(pathInClassPath));
+    public GitHubMockConfigFileSetupContext configFile(String pathInRepository) {
+        return configFile(null, pathInRepository);
     }
 
     @Override
-    public void configFileFromString(String pathInRepository, String configFile) {
-        when(fileDownloader.getFileContent(any(), eq(GitHubConfigFileProviderImpl.getFilePath(pathInRepository))))
-                .thenReturn(Optional.of(configFile));
+    public GitHubMockConfigFileSetupContext configFile(GHRepository repository, String pathInRepository) {
+        return new GitHubMockConfigFileSetupContext() {
+            @Override
+            public void fromClasspath(String pathInClasspath) throws IOException {
+                fromString(GitHubAppTestingContext.get().getFromClasspath(pathInClasspath));
+            }
+
+            @Override
+            public void fromString(String configFile) {
+                when(fileDownloader.getFileContent(repository == null ? any() : same(repository),
+                        eq(GitHubConfigFileProviderImpl.getFilePath(pathInRepository))))
+                        .thenReturn(Optional.of(configFile));
+            }
+        };
     }
 
     @Override

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -30,6 +30,7 @@ import org.mockito.Answers;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 
+import io.quarkiverse.githubapp.runtime.github.GitHubConfigFileProviderImpl;
 import io.quarkiverse.githubapp.runtime.github.GitHubFileDownloader;
 import io.quarkiverse.githubapp.runtime.github.GitHubService;
 import io.quarkiverse.githubapp.testing.dsl.GitHubMockContext;
@@ -96,7 +97,7 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
 
     @Override
     public void configFileFromString(String pathInRepository, String configFile) {
-        when(fileDownloader.getFileContent(any(), eq(getGitHubFilePath(pathInRepository))))
+        when(fileDownloader.getFileContent(any(), eq(GitHubConfigFileProviderImpl.getFilePath(pathInRepository))))
                 .thenReturn(Optional.of(configFile));
     }
 
@@ -179,14 +180,6 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
         for (MockMap<?, ?> mockMap : allMockMaps) {
             mockMap.map.clear();
         }
-    }
-
-    private static String getGitHubFilePath(String path) {
-        if (path.startsWith("/")) {
-            return path.substring(1);
-        }
-
-        return ".github/" + path;
     }
 
     private DefaultableMocking<? extends GHObject> ghObjectMocking(GHObject original) {

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -102,8 +102,8 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     }
 
     @Override
-    public GHRepository repository(String id) {
-        return repositories.getOrCreate(id).mock();
+    public GHRepository repository(String fullName) {
+        return repositories.getOrCreate(fullName).mock();
     }
 
     @Override


### PR DESCRIPTION
I.e. `GitHubConfigFileProvider`, useful in combination with `GitHubClientProvider`.

I tried to avoid duplicating code, which is why I moved the "request-scope cache" of config files to a dedicated bean.

I did not add any cache to `GitHubConfigFileProvider` for now, because there's already one for event listeners (no change there) and I don't anticipate a need for a cache in my own use case that doesn't involve event listeners.

Note one nice bonus: this could enable building the linting of configuration files directly into the GitHub app, through a PR event listener.