### PR TITLE
Correctly retrieve the requested ref when non-null in GitHubFileDownloader

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubFileDownloader.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/github/GitHubFileDownloader.java
@@ -24,7 +24,7 @@ public class GitHubFileDownloader {
     @SuppressWarnings("deprecation")
     public Optional<String> getFileContent(GHRepository ghRepository, String ref, String fullPath) {
         try {
-            GHContent ghContent = ghRepository.getFileContent(fullPath);
+            GHContent ghContent = ghRepository.getFileContent(fullPath, ref);
 
             return Optional.of(ghContent.getContent());
         } catch (GHFileNotFoundException e) {


### PR DESCRIPTION
When the ref is null, everything will stay as before.

This looks like an oversight...