### PR TITLE
Consistently use the full name as identifier for GHRepository mocks

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/githubapp/deployment/junit/GitHubMockContextImpl.java
+++ b/deployment/src/test/java/io/quarkiverse/githubapp/deployment/junit/GitHubMockContextImpl.java
@@ -61,7 +61,7 @@ public final class GitHubMockContextImpl {
     DefaultableMocking<? extends GHObject> ghObjectMocking(GHObject original) {
         Class<? extends GHObject> type = original.getClass();
         if (GHRepository.class.equals(type)) {
-            return repositories.getOrCreate(((GHRepository) original).getName());
+            return repositories.getOrCreate(((GHRepository) original).getFullName());
         } else {
             return nonRepositoryMockMap(type).getOrCreate(original.getId());
         }

--- a/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/DefaultPermissionCliTest.java
+++ b/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/DefaultPermissionCliTest.java
@@ -28,13 +28,13 @@ public class DefaultPermissionCliTest {
     void testNoPermissionSet() throws IOException {
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -47,13 +47,13 @@ public class DefaultPermissionCliTest {
 
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(false);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -69,13 +69,13 @@ public class DefaultPermissionCliTest {
     void testPermissionOverriddenRead() throws IOException {
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(false);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -88,13 +88,13 @@ public class DefaultPermissionCliTest {
 
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(false);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(false);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -110,13 +110,13 @@ public class DefaultPermissionCliTest {
     void testPermissionOverriddenAdmin() throws IOException {
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(true);
                 })
@@ -129,13 +129,13 @@ public class DefaultPermissionCliTest {
 
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -148,7 +148,7 @@ public class DefaultPermissionCliTest {
     }
 
     private void verifyHasPermission(GitHubMockVerificationContext mocks) throws IOException {
-        verify(mocks.repository("quarkus-bot-java-playground")).hasPermission(any(GHUser.class),
+        verify(mocks.repository("gsmet/quarkus-bot-java-playground")).hasPermission(any(GHUser.class),
                 any(GHPermissionType.class));
     }
 

--- a/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/DefaultTeamCliTest.java
+++ b/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/DefaultTeamCliTest.java
@@ -41,7 +41,7 @@ public class DefaultTeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(false);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-default-team-no-teams.json")
@@ -68,7 +68,7 @@ public class DefaultTeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(false);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-default-team-no-teams.json")
@@ -98,7 +98,7 @@ public class DefaultTeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(true);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-default-team-team2.json")
@@ -125,7 +125,7 @@ public class DefaultTeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(false);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-default-team-team2.json")
@@ -140,7 +140,7 @@ public class DefaultTeamCliTest {
     }
 
     private void verifyGetTeams(GitHubMockVerificationContext mocks) throws IOException {
-        verify(mocks.repository("quarkus-bot-java-playground")).getTeams();
+        verify(mocks.repository("gsmet/quarkus-bot-java-playground")).getTeams();
     }
 
     private void verifyGetSlug(GitHubMockVerificationContext mocks, long teamId) throws IOException {

--- a/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/PermissionCliTest.java
+++ b/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/PermissionCliTest.java
@@ -38,13 +38,13 @@ public class PermissionCliTest {
     void testWritePermission() throws IOException {
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -57,13 +57,13 @@ public class PermissionCliTest {
 
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(false);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -79,13 +79,13 @@ public class PermissionCliTest {
     void testAdminPermission() throws IOException {
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(true);
                 })
@@ -98,13 +98,13 @@ public class PermissionCliTest {
 
         given()
                 .github(mocks -> {
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.READ)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.WRITE)))
                             .thenReturn(true);
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").hasPermission(any(GHUser.class),
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").hasPermission(any(GHUser.class),
                             eq(GHPermissionType.ADMIN)))
                             .thenReturn(false);
                 })
@@ -117,7 +117,7 @@ public class PermissionCliTest {
     }
 
     private void verifyHasPermission(GitHubMockVerificationContext mocks) throws IOException {
-        verify(mocks.repository("quarkus-bot-java-playground")).hasPermission(any(GHUser.class),
+        verify(mocks.repository("gsmet/quarkus-bot-java-playground")).hasPermission(any(GHUser.class),
                 any(GHPermissionType.class));
     }
 

--- a/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/TeamCliTest.java
+++ b/integration-tests/command-airline/src/test/java/io/quarkiverse/githubapp/it/command/airline/TeamCliTest.java
@@ -42,7 +42,7 @@ public class TeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(false);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-team-team1.json")
@@ -69,7 +69,7 @@ public class TeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(true);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-team-team1.json")
@@ -99,7 +99,7 @@ public class TeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(false);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-team-two-teams.json")
@@ -126,7 +126,7 @@ public class TeamCliTest {
                     Mockito.when(team2.hasMember(any(GHUser.class))).thenReturn(true);
                     teams.add(team2);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-team-two-teams.json")
@@ -159,7 +159,7 @@ public class TeamCliTest {
                     Mockito.when(team3.hasMember(any(GHUser.class))).thenReturn(true);
                     teams.add(team3);
 
-                    Mockito.when(mocks.repository("quarkus-bot-java-playground").getTeams())
+                    Mockito.when(mocks.repository("gsmet/quarkus-bot-java-playground").getTeams())
                             .thenReturn(teams);
                 })
                 .when().payloadFromClasspath("/issue-comment-team-two-teams.json")
@@ -176,7 +176,7 @@ public class TeamCliTest {
     }
 
     private void verifyGetTeams(GitHubMockVerificationContext mocks) throws IOException {
-        verify(mocks.repository("quarkus-bot-java-playground")).getTeams();
+        verify(mocks.repository("gsmet/quarkus-bot-java-playground")).getTeams();
     }
 
     private void verifyGetSlug(GitHubMockVerificationContext mocks, long teamId) throws IOException {

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -208,7 +208,7 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
     private DefaultableMocking<? extends GHObject> ghObjectMocking(GHObject original) {
         Class<? extends GHObject> type = original.getClass();
         if (GHRepository.class.equals(type)) {
-            return repositories.getOrCreate(((GHRepository) original).getName());
+            return repositories.getOrCreate(((GHRepository) original).getFullName());
         } else {
             return nonRepositoryMockMap(type).getOrCreate(original.getId());
         }


### PR DESCRIPTION
@gsmet remember [this comment](https://github.com/quarkiverse/quarkus-github-app/pull/367#discussion_r968435020)? Well, this PR brings the fix you thought I was introducing (but at the time, I was not).

This will most likely break existing tests for applications that use the testing framework and whose event listeners rely on e.g. `payload.getRepository()` or `pullRequest.getRepository()`.

But I believe it's for the best, as the previous behavior was pretty inconsistent.

This might require bumping the major version number on the next release, but I'll leave this to your judgment.