### PR TITLE
Work around a weird behavior of smee.io

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.13.3.Final
+:quarkus-version: 2.14.1.Final
 :quarkus-github-app-version: 1.15.1
 
 :github-api-javadoc-root-url: https://github-api.kohsuke.org/apidocs/org/kohsuke/github

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/smee/SmeeIoForwarder.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/smee/SmeeIoForwarder.java
@@ -95,7 +95,16 @@ public class SmeeIoForwarder {
                 return;
             }
 
-            JsonNode rootNode = objectMapper.readTree(messageEvent.getData());
+            int startOfJsonObject = messageEvent.getData().indexOf('{');
+            if (startOfJsonObject == -1) {
+                return;
+            }
+
+            // for some reason, the message coming from smee.io sometimes includes a 'id: 123' at the beginning of the message
+            // let's be safe and drop anything before the start of the JSON object.
+            String data = messageEvent.getData().substring(startOfJsonObject);
+
+            JsonNode rootNode = objectMapper.readTree(data);
             JsonNode body = rootNode.get("body");
 
             if (body != null) {


### PR DESCRIPTION
Today, smee.io is sometimes adding a id: 123 line to the JSON payload making it invalid.
Make our parser a bit more flexible to work around it.