### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/command-airline/runtime/pom.xml
+++ b/command-airline/runtime/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>airline</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -55,8 +55,8 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145