### PR TITLE
Allow observation of WebHook Events

### DIFF
--- a/integration-tests/app/src/test/resources/webhook.json
+++ b/integration-tests/app/src/test/resources/webhook.json
@@ -1,0 +1,42 @@
+{
+    "zen": "Approachable is better than simple.",
+    "hook_id": 475941683,
+    "hook": {
+        "type": "SponsorsListing",
+        "id": 475941683,
+        "name": "web",
+        "active": true,
+        "events": [
+            "*"
+        ],
+        "config": {
+            "content_type": "json",
+            "secret": "secret",
+            "url": "https://webhook",
+            "insecure_ssl": "0"
+        },
+        "updated_at": "2024-05-02T13:35:48Z",
+        "created_at": "2024-05-02T13:35:48Z",
+        "sponsors_listing_node_id": "SL_kwHOCJzKmc4AAogu"
+    },
+    "sender": {
+        "login": "ebullient",
+        "id": 808713,
+        "node_id": "MDQ6VXNlcjgwODcxMw==",
+        "avatar_url": "https://avatars.githubusercontent.com/u/808713?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/ebullient",
+        "html_url": "https://github.com/ebullient",
+        "followers_url": "https://api.github.com/users/ebullient/followers",
+        "following_url": "https://api.github.com/users/ebullient/following{/other_user}",
+        "gists_url": "https://api.github.com/users/ebullient/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/ebullient/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/ebullient/subscriptions",
+        "organizations_url": "https://api.github.com/users/ebullient/orgs",
+        "repos_url": "https://api.github.com/users/ebullient/repos",
+        "events_url": "https://api.github.com/users/ebullient/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/ebullient/received_events",
+        "type": "User",
+        "site_admin": false
+    }
+}

--- a/integration-tests/testing-framework/src/test/resources/pr-opened-dependabot.json
+++ b/integration-tests/testing-framework/src/test/resources/pr-opened-dependabot.json
@@ -529,5 +529,9 @@
     "received_events_url": "https://api.github.com/users/dependabot%5Bbot%5D/received_events",
     "type": "Bot",
     "site_admin": false
+  },
+  "installation": {
+    "id": 13173124,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMTMxNzMxMjQ="
   }
 }

--- a/runtime/src/main/java/io/quarkiverse/githubapp/GitHubWebhookEvent.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/GitHubWebhookEvent.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.githubapp;
+
+import io.vertx.core.json.JsonObject;
+
+public class GitHubWebhookEvent {
+
+    private final String deliveryId;
+
+    private final String event;
+
+    private final String action;
+
+    private final String payload;
+
+    private final JsonObject parsedPayload;
+
+    private final boolean replayed;
+
+    public GitHubWebhookEvent(String deliveryId, String event, String action,
+            String payload, JsonObject parsedPayload, boolean replayed) {
+        this.deliveryId = deliveryId;
+        this.event = event;
+        this.action = action;
+        this.payload = payload;
+        this.parsedPayload = parsedPayload;
+        this.replayed = replayed;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public JsonObject getParsedPayload() {
+        if (parsedPayload == null) {
+            throw new IllegalStateException("getParsedPayload() may not be called on GitHubEvents that have been serialized");
+        }
+
+        return parsedPayload;
+    }
+
+    public boolean isReplayed() {
+        return replayed;
+    }
+
+    @Override
+    public String toString() {
+        return "GitHubWebhookEvent [deliveryId=" + deliveryId + ", event=" + event
+                + ", action=" + action + ", payload=" + payload + ", replayed=" + replayed + "]";
+    }
+}


### PR DESCRIPTION
The usecase: GitHub Sponsor events are pure WebHook events. They are not associated with or assigned to a GitHub App Installation.

It should be possible for my bot to handle those requests (too), but at the moment, the Quarkus GitHub App makes assumptions about the presence of an installation id.

This is a start for allowing plain webhook events to overlay handling (i.e. can also be routed or replayed w/ smee).

What I have is a (bad) start at managing these events.