### PR TITLE
Support events not containing an installation

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/githubapp/deployment/TokenGitHubClientsInjectionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/githubapp/deployment/TokenGitHubClientsInjectionTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.githubapp.deployment;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kohsuke.github.GHEventPayload;
+
+import io.quarkiverse.githubapp.TokenGitHubClients;
+import io.quarkiverse.githubapp.event.Label;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class TokenGitHubClientsInjectionTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(ListeningClass.class).addClass(ListeningClass2.class))
+            .withConfigurationResource("application-token.properties");
+
+    @Test
+    public void testGitHubGraphQLClientInjection() {
+    }
+
+    static class ListeningClass {
+
+        @Inject
+        TokenGitHubClients tokenGitHubClients;
+
+        void createLabel(@Label.Created GHEventPayload.Label labelPayload) {
+        }
+    }
+
+    static class ListeningClass2 {
+
+        void createLabel(@Label.Created GHEventPayload.Label labelPayload, TokenGitHubClients tokenGitHubClients) {
+        }
+    }
+}

--- a/deployment/src/test/resources/application-token.properties
+++ b/deployment/src/test/resources/application-token.properties
@@ -1,0 +1,2 @@
+quarkus.github-app.app-name=quarkus-github-app-test
+quarkus.github-app.personal-access-token=ghp_mytoken

--- a/docs/modules/ROOT/pages/developer-reference.adoc
+++ b/docs/modules/ROOT/pages/developer-reference.adoc
@@ -343,11 +343,41 @@ The injected `DynamicGraphQLClient` instance is authenticated as an installation
 `DynamicGraphQLClient` is a dynamic SmallRye GraphQL client.
 You can find more information about the SmallRye GraphQL client https://quarkus.io/guides/smallrye-graphql-client[here] and https://github.com/smallrye/smallrye-graphql[here].
 
-== Configuration Reference
+== Webhook events
 
-The Quarkus GitHub App extension exposes the following configuration properties:
+While Quarkus GitHub App was primarily designed as a tool to develop GitHub Apps,
+it is also possible to use it to handle your webhook requests.
 
-include::includes/quarkus-github-app.adoc[]
+It will take care of all the ceremony of authenticating the requests and will save you a lot of boilerplate.
+
+There are a few differences though:
+
+- You will have to use `@RawEvent` to listen to the events and get the raw JSON of the payload.
+- Webhook requests don't provide an installation id so we can't initialize an installation GitHub client nor a GraphQL client.
+
+The default `GitHub` REST client instance that can be injected is an application client and has so few permissions that it is not really useful.
+
+While it could be a major inconvenience, we present a nice feature dedicated to this use case in the following section.
+
+== Providing a personal access token
+
+When using Quarkus GitHub App, in most cases, the REST and GraphQL clients provided by the installation are what you are looking for:
+they have the permissions allowed for this GitHub App and it should be enough to do what your GitHub App has been designed for.
+
+However, there are corner cases where you might need a client with additional permissions,
+the most common one is when you deal with webhooks as presented in the previous section.
+
+For this situation, you can define a personal access token by using the `quarkus.github-app.personal-access-token` configuration property.
+The personal access token provided in this property will be used to initialize:
+
+- an authenticated `GitHub` REST client
+- an authenticated `DynamicGraphQL` GraphQL client
+
+These clients will be automatically injected in your methods when injecting clients *if the payload doesn't provide an installation id*
+(if it does provide one, the regular installation clients will be injected).
+
+It is also possible to directly obtain the clients authenticated with the personal access token by injecting the `TokenGitHubClients` CDI bean.
+It provides methods to get the authenticated REST and GraphQL clients.
 
 == Credentials provider
 
@@ -388,6 +418,12 @@ public class MyGitHubCustomizer implements GitHubCustomizer {
     }
 }
 ----
+
+== Configuration Reference
+
+The Quarkus GitHub App extension exposes the following configuration properties:
+
+include::includes/quarkus-github-app.adoc[]
 
 == Architecture Overview
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.11.3
+:quarkus-version: 3.13.2
 :quarkus-github-app-version: 2.6.0
 
 :github-api-javadoc-root-url: https://github-api.kohsuke.org/apidocs/org/kohsuke/github

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.13.2
+:quarkus-version: 3.13.3
 :quarkus-github-app-version: 2.6.0
 
 :github-api-javadoc-root-url: https://github-api.kohsuke.org/apidocs/org/kohsuke/github

--- a/docs/modules/ROOT/pages/includes/quarkus-github-app.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-github-app.adoc
@@ -241,6 +241,29 @@ endif::add-copy-button-to-env-var[]
 |`${quarkus.github-app.instance-endpoint}/graphql`
 
 
+a| [[quarkus-github-app_quarkus-github-app-personal-access-token]]`link:#quarkus-github-app_quarkus-github-app-personal-access-token[quarkus.github-app.personal-access-token]`
+
+
+[.description]
+--
+A personal access token for use with `TokenGitHubClients`.
+
+For standard use cases, you will use the installation client which comes with the installation permissions. It can be injected directly in your method.
+
+However, if your payload comes from a webhook and doesn't have an installation id, it's handy to be able to use a client authenticated with a personal access token as the application client permissions are very limited.
+
+This token will be used to authenticate the clients provided by `TokenGitHubClients`.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GITHUB_APP_PERSONAL_ACCESS_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GITHUB_APP_PERSONAL_ACCESS_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 a| [[quarkus-github-app_quarkus-github-app-debug-payload-directory]]`link:#quarkus-github-app_quarkus-github-app-debug-payload-directory[quarkus.github-app.debug.payload-directory]`
 
 

--- a/integration-tests/app/src/main/java/io/quarkiverse/githubapp/it/app/RawEventListener.java
+++ b/integration-tests/app/src/main/java/io/quarkiverse/githubapp/it/app/RawEventListener.java
@@ -6,11 +6,12 @@ import org.kohsuke.github.GitHub;
 
 import io.quarkiverse.githubapp.GitHubEvent;
 import io.quarkiverse.githubapp.event.RawEvent;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 public class RawEventListener {
 
-    void testRawEventListenedTo(@RawEvent(event = "issues", action = "opened") GitHubEvent gitHubEvent, GitHub gitHub)
-            throws IOException {
+    void testRawEventListenedTo(@RawEvent(event = "issues", action = "opened") GitHubEvent gitHubEvent, GitHub gitHub,
+            DynamicGraphQLClient graphQLClient) throws IOException {
         assert gitHubEvent.getEvent().equals("issues");
         assert gitHubEvent.getAction().equals("opened");
 

--- a/integration-tests/app/src/main/java/io/quarkiverse/githubapp/it/app/RawEventListener.java
+++ b/integration-tests/app/src/main/java/io/quarkiverse/githubapp/it/app/RawEventListener.java
@@ -36,8 +36,8 @@ public class RawEventListener {
     }
 
     void testRawEventCatchAllEventAction(@RawEvent GitHubEvent gitHubEvent, GitHub gitHub) throws IOException {
-        assert gitHubEvent.getEvent().equals("issues");
-        assert gitHubEvent.getAction().equals("opened");
+        assert gitHubEvent.getEvent() != null;
+        assert gitHubEvent.getAction() != null;
 
         gitHub.getRepository("test/test").getIssue(1).addLabels("testRawEventCatchAllEventAction");
     }

--- a/integration-tests/app/src/main/java/io/quarkiverse/githubapp/it/app/RawEventListenerWithoutInstallation.java
+++ b/integration-tests/app/src/main/java/io/quarkiverse/githubapp/it/app/RawEventListenerWithoutInstallation.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.githubapp.it.app;
+
+import java.io.IOException;
+
+import org.kohsuke.github.GitHub;
+
+import io.quarkiverse.githubapp.GitHubEvent;
+import io.quarkiverse.githubapp.event.RawEvent;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+
+public class RawEventListenerWithoutInstallation {
+
+    public static final String EVENT_TYPE = "sponsor";
+
+    void testRawEventListenerWithoutInstallation(@RawEvent(event = EVENT_TYPE, action = "sponsored") GitHubEvent gitHubEvent,
+            GitHub gitHub,
+            DynamicGraphQLClient graphQLClient) throws IOException {
+        assert gitHubEvent.getEvent().equals(EVENT_TYPE);
+        assert gitHubEvent.getAction().equals("sponsored");
+
+        assert graphQLClient != null;
+        assert gitHub != null;
+
+        gitHub.getRepository("test/test").getIssue(1).addLabels("testRawEventListenerWithoutInstallation");
+    }
+}

--- a/integration-tests/app/src/main/resources/application.properties
+++ b/integration-tests/app/src/main/resources/application.properties
@@ -28,3 +28,4 @@ E0/FAoGATJvuAfgy9uiKR7za7MigYVacE0u4aD1sF7v6D4AFqBOGquPQQhePSdz9\
 G/UUwySoo+AQ+rd2EPhyexjqXBhRGe+EDGFVFivaQzTT8/5bt/VddbTcw2IpmXYj\
 LW6V8BbcP5MRhd2JQSRh16nWwSQJ2BdpUZFwayEEQ6UcrMfqvA0=\
 -----END RSA PRIVATE KEY-----
+%test.quarkus.github-app.personal-access-token=ghp_mytoken

--- a/integration-tests/app/src/test/java/io/quarkiverse/githubapp/it/app/RawEventWithoutInstallationTest.java
+++ b/integration-tests/app/src/test/java/io/quarkiverse/githubapp/it/app/RawEventWithoutInstallationTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.githubapp.it.app;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@GitHubAppTest
+public class RawEventWithoutInstallationTest {
+
+    @Test
+    void testRawEventWithoutInstallation() throws IOException {
+        given().github(mocks -> {
+            when(mocks.repository("test/test").getIssue(1))
+                    .thenReturn(mocks.issue(1L));
+        })
+                .when().payloadFromClasspath("/event-without-installation.json")
+                .rawEvent(RawEventListenerWithoutInstallation.EVENT_TYPE)
+                .then().github(mocks -> {
+                    verify(mocks.issue(1))
+                            .addLabels("testRawEventListenerWithoutInstallation");
+                    verify(mocks.issue(1))
+                            .addLabels("testRawEventCatchAllEventAction");
+                });
+    }
+}

--- a/integration-tests/app/src/test/resources/event-without-installation.json
+++ b/integration-tests/app/src/test/resources/event-without-installation.json
@@ -1,0 +1,23 @@
+{
+  "action": "sponsored",
+  "sender": {
+    "login": "yrodiere",
+    "id": 412878,
+    "node_id": "MDQ6VXNlcjQxMjg3OA==",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/412878?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/yrodiere",
+    "html_url": "https://github.com/yrodiere",
+    "followers_url": "https://api.github.com/users/yrodiere/followers",
+    "following_url": "https://api.github.com/users/yrodiere/following{/other_user}",
+    "gists_url": "https://api.github.com/users/yrodiere/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/yrodiere/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/yrodiere/subscriptions",
+    "organizations_url": "https://api.github.com/users/yrodiere/orgs",
+    "repos_url": "https://api.github.com/users/yrodiere/repos",
+    "events_url": "https://api.github.com/users/yrodiere/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/yrodiere/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/TokenGitHubClients.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/TokenGitHubClients.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.githubapp;
+
+import jakarta.inject.Singleton;
+
+import org.kohsuke.github.GitHub;
+
+import io.quarkiverse.githubapp.runtime.github.GitHubService;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
+
+@Singleton
+public class TokenGitHubClients {
+
+    private final GitHubService gitHubService;
+
+    TokenGitHubClients(GitHubService gitHubService) {
+        this.gitHubService = gitHubService;
+    }
+
+    public GitHub getRestClient() {
+        return gitHubService.getTokenRestClient();
+    }
+
+    public DynamicGraphQLClient getGraphQLClient() {
+        return gitHubService.getTokenGraphQLClient();
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/Routes.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/Routes.java
@@ -168,16 +168,7 @@ public class Routes {
             }
         }
 
-        if (launchMode == LaunchMode.TEST || launchMode == LaunchMode.DEVELOPMENT) {
-            long defaultInstallationId = 1L;
-            LOG.infof(
-                    "Payload is lacking an installation ID; the payload was probably copy/pasted from GitHub's delivery history?"
-                            + " Defaulting to installation ID %s",
-                    defaultInstallationId);
-            return defaultInstallationId;
-        }
-
-        throw new IllegalStateException("Unable to extract installation id from payload");
+        return null;
     }
 
     private static String extractRepository(JsonObject body) {

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/CheckedConfigProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/CheckedConfigProvider.java
@@ -119,6 +119,10 @@ public class CheckedConfigProvider {
         return gitHubAppRuntimeConfig.graphqlApiEndpoint();
     }
 
+    public Optional<String> personalAccessToken() {
+        return gitHubAppRuntimeConfig.personalAccessToken();
+    }
+
     public Debug debug() {
         return gitHubAppRuntimeConfig.debug();
     }

--- a/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/GitHubAppRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/githubapp/runtime/config/GitHubAppRuntimeConfig.java
@@ -12,6 +12,7 @@ import io.quarkus.runtime.configuration.TrimmedStringConverter;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
+import io.smallrye.graphql.client.dynamic.api.DynamicGraphQLClient;
 
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.github-app")
@@ -116,6 +117,21 @@ public interface GitHubAppRuntimeConfig {
     @WithDefault("${quarkus.github-app.instance-endpoint}/graphql")
     @WithConverter(TrimmedStringConverter.class)
     String graphqlApiEndpoint();
+
+    /**
+     * A personal access token for use with {@code TokenGitHubClients} or when no installation id is provided in the payload.
+     * <p>
+     * For standard use cases, you will use the installation client which comes with the installation permissions. It can be
+     * injected directly in your method.
+     * <p>
+     * However, if your payload comes from a webhook and doesn't have an installation id, it's handy to be able to use a
+     * client authenticated with a personal access token as the application client permissions are very limited.
+     * <p>
+     * This token will be used to authenticate the clients provided by {@code TokenGitHubClients} and clients
+     * authenticated with this personal access token will be automatically provided when injecting {@code GitHub} or
+     * {@code DynamicGraphQLClient} in your method, when the payload doesn't provide an installation id.
+     */
+    Optional<String> personalAccessToken();
 
     /**
      * Debug configuration.

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/EventSenderOptions.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/dsl/EventSenderOptions.java
@@ -21,4 +21,8 @@ public interface EventSenderOptions {
     EventHandlingResponse event(GHEvent event);
 
     EventHandlingResponse event(GHEvent event, boolean ignoreExceptions);
+
+    EventHandlingResponse rawEvent(String event);
+
+    EventHandlingResponse rawEvent(String event, boolean ignoreExceptions);
 }

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/EventSenderOptionsImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/EventSenderOptionsImpl.java
@@ -86,12 +86,22 @@ final class EventSenderOptionsImpl implements EventSenderOptions {
 
     @Override
     public EventHandlingResponseImpl event(GHEvent event, boolean ignoreExceptions) {
+        return rawEvent(symbol(event), ignoreExceptions);
+    }
+
+    @Override
+    public EventHandlingResponseImpl rawEvent(String event) {
+        return rawEvent(event, false);
+    }
+
+    @Override
+    public EventHandlingResponseImpl rawEvent(String event, boolean ignoreExceptions) {
         HttpRequest request = HttpRequest.newBuilder(buildUrl())
                 .POST(BodyPublishers.ofString(payload))
                 .header(Headers.CONTENT_TYPE, contentType)
                 .header(Headers.X_REQUEST_ID, (requestId == null ? UUID.randomUUID() : requestId).toString())
                 .header(Headers.X_GITHUB_DELIVERY, (deliveryId == null ? UUID.randomUUID() : deliveryId).toString())
-                .header(Headers.X_GITHUB_EVENT, symbol(event))
+                .header(Headers.X_GITHUB_EVENT, event)
                 .build();
 
         // Only stub these methods when we know they are going to get called;

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/EventSenderOptionsImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/EventSenderOptionsImpl.java
@@ -29,7 +29,7 @@ final class EventSenderOptionsImpl implements EventSenderOptions {
 
     private UUID requestId;
     private UUID deliveryId;
-    private long installationId;
+    private Long installationId;
     private String payload;
     private String contentType;
 

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubAppTestingCallback.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubAppTestingCallback.java
@@ -24,6 +24,11 @@ public final class GitHubAppTestingCallback
                 .orElse(false);
     }
 
+    static boolean hasPersonalAccessToken() {
+        return ConfigProviderResolver.instance().getConfig()
+                .getOptionalValue("quarkus.github-app.personal-access-token", String.class).isPresent();
+    }
+
     @Override
     public void afterConstruct(Object testInstance) {
         if (!isEnabled()) {

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -181,8 +181,8 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
                 .thenAnswer(invocation -> installationGraphQLClient(invocation.getArgument(0, Long.class)));
     }
 
-    void initEventStubs(long installationId) {
-        GitHub clientMock = installationClient(installationId);
+    void initEventStubs(Long installationId) {
+        GitHub clientMock = applicationOrInstallationClient(installationId);
         MockitoUtils.doWithMockedClassClassLoader(GitHub.class, () -> {
             try {
                 when(clientMock.parseEventPayload(any(), any())).thenAnswer(invocation -> {

--- a/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
+++ b/testing/src/main/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImpl.java
@@ -93,6 +93,15 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
                 .mock();
     }
 
+    public GitHub tokenRestClient() {
+        // the token client should have all the features of an installation client
+        return installationClient(-1);
+    }
+
+    public DynamicGraphQLClient tokenGraphQLClient() {
+        return installationGraphQLClient(-1);
+    }
+
     @Override
     public GitHubMockConfigFileSetupContext configFile(String pathInRepository) {
         return configFile(null, pathInRepository);
@@ -179,6 +188,14 @@ public final class GitHubMockContextImpl implements GitHubMockContext, GitHubMoc
 
         when(service.getInstallationGraphQLClient(anyLong()))
                 .thenAnswer(invocation -> installationGraphQLClient(invocation.getArgument(0, Long.class)));
+
+        if (GitHubAppTestingCallback.hasPersonalAccessToken()) {
+            when(service.getTokenOrApplicationClient()).thenAnswer(invocation -> tokenRestClient());
+            when(service.getTokenGraphQLClientOrNull()).thenAnswer(invocation -> tokenGraphQLClient());
+        } else {
+            when(service.getTokenOrApplicationClient()).thenAnswer(invocation -> applicationClient());
+            when(service.getTokenGraphQLClientOrNull()).thenAnswer(invocation -> null);
+        }
     }
 
     void initEventStubs(Long installationId) {

--- a/testing/src/test/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImplEventMocksTest.java
+++ b/testing/src/test/java/io/quarkiverse/githubapp/testing/internal/GitHubMockContextImplEventMocksTest.java
@@ -35,7 +35,7 @@ public class GitHubMockContextImplEventMocksTest {
     @BeforeEach
     public void init() {
         context.init();
-        context.initEventStubs(123);
+        context.initEventStubs(123L);
         client = context.installationClient(123);
     }
 


### PR DESCRIPTION
This is the case of ping for instance but also of various web hooks.

Note that in this case, you can't get an installation client:

- The injected GitHub client will be the very limited application one (I'm even wondering if I should prevent people from using it)
- The GraphQL client cannot be injected.

For anything advanced, you will have to create your own GitHub client with a token.

Fixes #386